### PR TITLE
fix: change return types in application.py functions

### DIFF
--- a/dm_cli/application.py
+++ b/dm_cli/application.py
@@ -116,7 +116,7 @@ def get_app_dir_structure(path: Path) -> [Path, Path]:
     return data_sources_dir, data_dir
 
 
-def get_data_source_definition_files(path: Path) -> list[str]:
+def get_data_source_definition_files(path: Path) -> List[str]:
     """Get all JSON files found in <path>."""
     return [
         filename
@@ -125,7 +125,7 @@ def get_data_source_definition_files(path: Path) -> list[str]:
     ]
 
 
-def get_subdirectories(path: Path) -> list[str]:
+def get_subdirectories(path: Path) -> List[str]:
     """Get all subdirectories found in <path>."""
     if not isinstance(path, Path):
         path = Path(path)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.6",
+    version="0.1.7",
     author="",
     author_email="",
     license="MIT",


### PR DESCRIPTION
## What does this pull request change?
fix typing syntax to support py3.8
## Why is this pull request needed?
if using python3.8 the dm-cli gives error
![image](https://user-images.githubusercontent.com/69512295/201606085-11fc6fd1-2aa2-4a4a-bf02-3d784b43c57c.png)

## Issues related to this change
closes #20 
