### PR TITLE
fix: print error message and exit on failed import

### DIFF
--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -148,7 +148,7 @@ def pkg_cli(context):
 @click.argument("path", required=True)
 @click.argument("data_source", required=True)
 @click.pass_context
-def import_package(context, path: str, data_source: str):
+def import_package(context, path: str, data_source: str) -> bool:
     """
     Import the package <path> to the given data source
     """
@@ -177,11 +177,12 @@ def import_package(context, path: str, data_source: str):
         import_package_tree(root_package, data_source)
         click.echo(f"\tImported package '{data_source}/{data_source_data_dir.name}'")
     except ApplicationException as error:
-        raise ApplicationException(error.body)
+        click.echo(error.message)
+        return False
     except Exception as error:
         traceback.print_exc()
-        raise Exception(f"\tSomething went wrong trying to upload the package '{data_source}/{data_source_data_dir.name}' to DMSS; {error}")
-
+        click.echo(f"\tSomething went wrong trying to upload the package '{data_source}/{data_source_data_dir.name}' to DMSS; {error}")
+        return False
 
 @pkg_cli.command("import-all", help="Import all packages found in the directory given by <path> to the given data source")
 @click.argument("path", required=True)
@@ -204,12 +205,15 @@ def import_packages(context, path: str, data_source: str):
             emoji.emojize(f"\t:warning: No packages were found in '{data_source_data_dir}'.")
         )
 
-    def thread_function(package_name: str):
+    def thread_function(package_name: str) -> bool:
         filepath = data_source_data_dir.joinpath(package_name)
-        context.invoke(import_package, data_source=data_source, path=filepath)
+        return context.invoke(import_package, data_source=data_source, path=filepath)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(thread_function, packages_to_import)
+        results = executor.map(thread_function, packages_to_import)
+        for r in results:
+            if not r:
+                exit(1)  # If any of the parallel functions did not return True, they fail, and so we exit with 1
 
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.8",
+    version="0.1.9",
     author="",
     author_email="",
     license="MIT",

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/demoApplication.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/demoApplication.json
@@ -1,0 +1,6 @@
+{
+  "_id": "4483c9b0-d505-46c9-a157-94c79f4d7a6a",
+  "type": "TEST-MODELS:DemoApplication",
+  "label": "Demo App",
+  "dataSources": ["DemoApplicationDataSource"]
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/package.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "instances",
+  "type": "CORE:Package",
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "sys"
+      },
+      {
+        "alias": "TEST-MODELS",
+        "address": "DemoApplicationDataSource/models",
+        "version": "0.0.1",
+        "protocol": "sys"
+      }
+    ]
+  }
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
@@ -1,0 +1,20 @@
+{
+  "name": "Car",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:NamedEntity"],
+  "description": "",
+  "attributes": [
+    {
+      "name": "color",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    },
+    {
+      "name": "wheels",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "/CarPackage/Wheel",
+      "dimensions": "*"
+    }
+  ],
+  "uiRecipes": []
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Wheel.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Wheel.json
@@ -1,0 +1,20 @@
+{
+  "type": "CORE:Blueprint",
+  "name": "Wheel",
+  "attributes": [
+    {
+      "name": "brand",
+      "optional": false,
+      "attributeType": "string",
+      "type": "CORE:BlueprintAttribute"
+    },
+    {
+      "name": "dimensions",
+      "attributeType": "string",
+      "type": "CORE:BlueprintAttribute",
+      "label": "string"
+    }
+  ],
+  "storageRecipes": [],
+  "uiRecipes": []
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/DemoApplication.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/DemoApplication.json
@@ -1,0 +1,29 @@
+{
+  "name": "DemoApplication",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:Application"],
+  "description": "",
+  "attributes": [
+    {
+      "name": "label",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "optional": true
+    },
+    {
+      "name": "dataSources",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string",
+      "dimensions": "*",
+      "optional": false
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "Default",
+      "type": "CORE:UiRecipe",
+      "plugin": "demoApp",
+      "category": "Application"
+    }
+  ]
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/package.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "models",
+  "type": "CORE:Package",
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "sys"
+      }
+    ]
+  }
+}

--- a/tests/test_data/test_app_dir_struct/data_sources/DemoApplicationDataSource.json
+++ b/tests/test_data/test_app_dir_struct/data_sources/DemoApplicationDataSource.json
@@ -1,0 +1,19 @@
+{
+  "name": "DemoApplicationDataSource",
+  "repositories": {
+    "forecastDB": {
+      "type": "mongo-db",
+      "host": "db",
+      "port": 27017,
+      "username": "maf",
+      "password": "maf",
+      "tls": false,
+      "database": "demo-app",
+      "collection": "default",
+      "data_types": [
+        "blob"
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
## What does this pull request change?
- Print error message and exit on failed package import (no more stack traces)
- Added a test "app" directory

## Why is this pull request needed?
The import would fail with no feedback

## Issues related to this change
none
