### PR TITLE
fix: replace_relative_references no longer fails on empty objects

### DIFF
--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -159,7 +159,7 @@ def replace_relative_references(
                 )
 
     # If the value is a complex type, dig down recursively
-    if isinstance(value, dict):
+    if isinstance(value, dict) and value != {}:
         # First check if the type is a blob type
         if (
             replace_relative_references(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.10",
+    version="0.1.11",
     author="",
     author_email="",
     license="MIT",


### PR DESCRIPTION
## What does this pull request change?
reset command no longer fails on empty object.
The example entity failed before: because "input" attribute is empty
![image](https://user-images.githubusercontent.com/69512295/202204730-c9638443-4d56-411c-bc42-92680f8699c3.png)

## Why is this pull request needed?
bug fix
## Issues related to this change


