### PR TITLE
Ci/add tests and fix dm init bug

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,4 +16,13 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-  # TODO run tests
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: install requirements
+        run: pip install -r requirements.txt && pip install -r dev-requirements.txt && pip install .
+
+      - name: run pytest
+        run: pytest

--- a/dm_cli/application.py
+++ b/dm_cli/application.py
@@ -98,6 +98,10 @@ def _load_app_settings(home: str):
 
 
 def get_app_dir_structure(path: Path) -> [Path, Path]:
+    app_dir = Path(path)
+    if not app_dir.is_dir():
+        raise FileNotFoundError(f"The path '{path}' is not a directory.")
+
     # Check for presence of expected directories, 'data_sources' and 'data'
     data_sources_dir = path.joinpath("data_sources")
     data_dir = path.joinpath("data")

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -53,11 +53,9 @@ def ds_cli(context):
 @ds_cli.command("import", help="Import a datasource, where <path> is the path to a data source definition (JSON).")
 @click.argument("path", required=True)
 @click.pass_context
-def import_data_source(context, path: str, fail_if_ds_exists=True):
+def import_data_source(context, path: str):
     """
     Import a single data source definition to DMSS.
-
-    The flag fail_if_ds_exists can be used to throw an error if data source already exists.
     """
     data_source_path = Path(path)
     if not data_source_path.is_file():
@@ -73,10 +71,7 @@ def import_data_source(context, path: str, fail_if_ds_exists=True):
             dmss_api.data_source_save(document["name"], data_source_request=document)
             click.echo(f"\tImported data source '{document['name']}'")
         except (ApiException, KeyError) as error:
-            if fail_if_ds_exists and error.status == 400:
-                raise ImportError(f"\tA data source with name {document['name']} already exists. "
-                                  f"Please run the command 'dm reset' to fix the issue.")
-            elif error.status == 400:
+            if error.status == 400:
                 click.echo(
                     emoji.emojize(
                         f"\t:warning: Could not import data source '{document['name']}'. "
@@ -113,7 +108,7 @@ def import_data_sources(context, path: str):
         context.invoke(import_data_source, path=filepath)
 
 
-@ds_cli.command("reset", help="Reset the data source (deletes and reuploads packages).")
+@ds_cli.command("reset", help="Reset a single data source (deletes and reuploads packages).")
 @click.argument("data_source", required=True)
 @click.argument("path", required=False, default=".")
 @click.pass_context
@@ -137,10 +132,8 @@ def reset_data_source(context, data_source: str, path: str):
     if not data_source_data_dir.is_dir():
         raise FileNotFoundError(f"There is no data source directory for '{data_source}' in '{data_dir}'.")
 
-    # Delete all packages in the data source
-    context.invoke(delete_packages, data_source=data_source, path=data_source_data_dir)
     # Import all packages in the data source
-    context.invoke(init, path=path, FAIL_IF_DS_EXISTS=False)
+    context.invoke(init, path=path)
 
 
 @cli.group("pkg", help="Subcommand for working with packages")
@@ -275,20 +268,17 @@ def delete_packages(context, data_source: str, path: str):
         executor.map(thread_function, packages)
 
 
-@cli.command(help="Initialize the data sources and import all packages. (Only use this command if datasources do not exist in DMSS)")
+@cli.command(help="Initialize the data sources and import all packages.")
 @click.argument("path", required=False, default=".")
 @click.pass_context
-def init(context, path: str, fail_if_ds_exists=True):
+def init(context, path: str):
     """
     Initialize the data sources and import all packages.
-    By default, fail_if_ds_exists is set to True. This function will not work if data source already exist in DMSS.
+    The packages in a data sources will be deleted before data sources are imported.
     """
-    app_dir = Path(path)
-    if not app_dir.is_dir():
-        raise FileNotFoundError(f"The path '{path}' is not a directory.")
 
     # Check for presence of expected directories, 'data_sources' and 'data'
-    data_sources_dir, data_dir = get_app_dir_structure(app_dir)
+    data_sources_dir, data_dir = get_app_dir_structure(Path(path))
 
     data_source_definitions = get_data_source_definition_files(data_sources_dir)
     if not data_source_definitions:
@@ -312,7 +302,10 @@ def init(context, path: str, fail_if_ds_exists=True):
             )
             continue
 
-        context.invoke(import_data_source, path=data_source_definition_filepath, fail_if_ds_exists=fail_if_ds_exists)
+        # Delete all packages in the data source
+        context.invoke(delete_packages, data_source=data_source_name, path=data_source_data_dir)
+
+        context.invoke(import_data_source, path=data_source_definition_filepath)
         context.invoke(import_packages, path=data_source_data_dir, data_source=data_source_name)
 
 
@@ -323,12 +316,8 @@ def reset(context, path: str):
     """
     Reset all data sources (deletes and reuploads all packages)
     """
-    app_dir = Path(path)
-    if not app_dir.is_dir():
-        raise FileNotFoundError(f"The path '{path}' is not a directory.")
-
     # Check for presence of expected directories, 'data_sources' and 'data'
-    data_sources_dir, data_dir = get_app_dir_structure(app_dir)
+    data_sources_dir, data_dir = get_app_dir_structure(Path(path))
 
     data_source_definitions = get_data_source_definition_files(data_sources_dir)
     if not data_source_definitions:

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -53,9 +53,11 @@ def ds_cli(context):
 @ds_cli.command("import", help="Import a datasource, where <path> is the path to a data source definition (JSON).")
 @click.argument("path", required=True)
 @click.pass_context
-def import_data_source(context, path: str):
+def import_data_source(context, path: str, fail_if_ds_exists=True):
     """
-    Import a single data source definition to DMSS
+    Import a single data source definition to DMSS.
+
+    The flag fail_if_ds_exists can be used to throw an error if data source already exists.
     """
     data_source_path = Path(path)
     if not data_source_path.is_file():
@@ -71,7 +73,10 @@ def import_data_source(context, path: str):
             dmss_api.data_source_save(document["name"], data_source_request=document)
             click.echo(f"\tImported data source '{document['name']}'")
         except (ApiException, KeyError) as error:
-            if error.status == 400:
+            if fail_if_ds_exists and error.status == 400:
+                raise ImportError(f"\tA data source with name {document['name']} already exists. "
+                                  f"Please run the command 'dm reset' to fix the issue.")
+            elif error.status == 400:
                 click.echo(
                     emoji.emojize(
                         f"\t:warning: Could not import data source '{document['name']}'. "
@@ -135,7 +140,7 @@ def reset_data_source(context, data_source: str, path: str):
     # Delete all packages in the data source
     context.invoke(delete_packages, data_source=data_source, path=data_source_data_dir)
     # Import all packages in the data source
-    context.invoke(init, path=path)
+    context.invoke(init, path=path, FAIL_IF_DS_EXISTS=False)
 
 
 @cli.group("pkg", help="Subcommand for working with packages")
@@ -231,7 +236,7 @@ def delete_package(context, data_source: str, package: str, silent: bool = False
 
     try:
         # Delete the document in DMSS
-        dmss_api.document_remove_by_path(data_source, directory=package)
+        response = dmss_api.document_remove_by_path(data_source, directory=package)
         if not silent:
             click.echo(f"\tDeleted package '{data_source}/{package}'")
     except Exception as error:
@@ -270,12 +275,13 @@ def delete_packages(context, data_source: str, path: str):
         executor.map(thread_function, packages)
 
 
-@cli.command(help="Initialize the data sources and import all packages.")
+@cli.command(help="Initialize the data sources and import all packages. (Only use this command if datasources do not exist in DMSS)")
 @click.argument("path", required=False, default=".")
 @click.pass_context
-def init(context, path: str):
+def init(context, path: str, fail_if_ds_exists=True):
     """
     Initialize the data sources and import all packages.
+    By default, fail_if_ds_exists is set to True. This function will not work if data source already exist in DMSS.
     """
     app_dir = Path(path)
     if not app_dir.is_dir():
@@ -306,7 +312,7 @@ def init(context, path: str):
             )
             continue
 
-        context.invoke(import_data_source, path=data_source_definition_filepath)
+        context.invoke(import_data_source, path=data_source_definition_filepath, fail_if_ds_exists=fail_if_ds_exists)
         context.invoke(import_packages, path=data_source_data_dir, data_source=data_source_name)
 
 

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -2,7 +2,7 @@ import io
 import json
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Union
 from uuid import UUID, uuid4
 from zipfile import ZipFile
 
@@ -98,7 +98,7 @@ def replace_relative_references(
     value,
     reference_table: dict = None,
     zip_file: ZipFile = None,
-    dependencies: List[Dependency] | None = None,
+    dependencies: Union[List[Dependency], None] = None,
 ) -> Any:
     """
     Takes a key-value pair and returns the passed value, with relative references updated with absolute ones found in the 'reference_table'.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.12",
+    version="0.1.13",
     author="",
     author_email="",
     license="MIT",

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/externalFile.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/externalFile.json
@@ -1,0 +1,10 @@
+ {
+  "_id": "47b4d893-3ab4-4ad2-9bd9-9614acb066c4",
+  "type": "TEST-MODELS:ExternalFile",
+  "name": "example-file-as-blob",
+  "blob": {
+    "name": "/nameList.txt",
+    "type": "CORE:Blob",
+    "_blob_id": "05af2773-6118-4bfd-a427-9485b30fc9db"
+  }
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/nameList.txt
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/nameList.txt
@@ -1,0 +1,4 @@
+Hans
+Andreas
+Pia
+Lise

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExternalFile.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExternalFile.json
@@ -1,0 +1,24 @@
+{
+  "name": "ExternalFile",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:NamedEntity"],
+  "description": "Blueprint with blob",
+  "attributes": [
+    {
+      "type": "CORE:BlueprintAttribute",
+      "name": "blob",
+      "description": "external file as blob",
+      "attributeType": "CORE:Blob",
+      "contained": true
+    },
+    {
+      "type": "CORE:BlueprintAttribute",
+      "name": "tag",
+      "description": "",
+      "attributeType": "string",
+      "optional": true
+    }
+  ],
+  "uiRecipes": [
+  ]
+}


### PR DESCRIPTION
## What does this pull request change?
- run tests in CI
- add example with blob to test data
- fix bug with dm init command. There was an issue with running dm init when a datasources already exists in DMSS.  ~Therefore, the user should not be allowed to run dm init if data sources already exists.~ 
now, the init dm command will delete packages before trying to upload new datasource

 
## Why is this pull request needed?

## Issues related to this change
closes #25 
