### PR TITLE
feature: respect meta data defined in entities

### DIFF
--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -175,7 +175,7 @@ def import_package(context, path: str, data_source: str) -> bool:
         import_package_tree(root_package, data_source)
         click.echo(f"\tImported package '{data_source}/{data_source_data_dir.name}'")
     except ApplicationException as error:
-        click.echo(error.message)
+        click.echo(f"\nERROR: {error.message}")
         return False
     except Exception as error:
         traceback.print_exc()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.13",
+    version="0.1.14",
     author="",
     author_email="",
     license="MIT",

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
@@ -3,6 +3,18 @@
   "type": "CORE:Blueprint",
   "extends": ["CORE:NamedEntity"],
   "description": "",
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "CORE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "sys"
+      }
+    ]
+  },
   "attributes": [
     {
       "name": "color",


### PR DESCRIPTION
## What does this pull request change?
- Read "_meta_" from all entities, not just root packages
- Will not allow multiple dependencies with the same alias if the values are different

## Why is this pull request needed?
- The user might define some dependencies further down the "tree"

## Issues related to this change
none
