### PR TITLE
fix: do not include package.json as an entity in a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ app
     └── DemoApplicationDataSource.json
 ```
 
+To add meta information to a package (for example to the models root package), a file with name "package.json" can be placed inside the folder.
+
+
 ### Supported reference syntax
 The CLI tool will understand and resolve these kind of type reference schemas during import.
 All values with one of these keys; `("type", "attributeType", "extends", "_blueprintPath_")` will be evaluated for resolution.

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -75,6 +75,10 @@ def replace_relative_references(
 
 def add_file_to_package(path: Path, package: Package, document: dict) -> None:
     if len(path.parts) == 1:  # End of path means the actual document
+        if path.name.endswith("package.json"):
+            # if document is a package.json file, add meta info to package instead of adding it to content list.
+            package.meta = document["_meta_"]
+            return
         # Create a UUID if the document does not have one
         package.content.append({**document, "_id": document.get("_id", str(uuid4()))})
         return
@@ -132,7 +136,7 @@ def upload_blobs_in_document(document: dict, data_source_id: str) -> dict:
 
 def import_package_tree(root_package: Package, data_source_id: str) -> None:
     documents_to_upload: List[dict] = [root_package.to_dict()]
-    root_package.traverse_documents(lambda document: documents_to_upload.append(document))
+    root_package.traverse_documents(lambda document, **kwargs: documents_to_upload.append(document))
     root_package.traverse_package(lambda package: documents_to_upload.append(package.to_dict()))
 
     with IncrementalBar(

--- a/dm_cli/package_tree_from_zip.py
+++ b/dm_cli/package_tree_from_zip.py
@@ -37,7 +37,13 @@ def package_tree_from_zip(data_source_id: str, zip_package: io.BytesIO) -> Packa
         )
 
         package_entity = json.loads(zip_file.read(package_file.filename)) if package_file else {}
+        if package_file in zip_file.filelist:
+            zip_file.filelist.remove(package_file)
         dependencies: Dict[str, Dependency] = {}
+        package_dependencies = {
+            v["alias"]: Dependency(**v) for v in package_entity.get("_meta_", {}).get("dependencies", [])
+        }
+        dependencies.update(package_dependencies)
         root_package = Package(
             name=package_entity.get("name", folder_name),
             is_root=True,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.18",
+    version="0.1.19",
     author="",
     author_email="",
     license="MIT",

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/EnginePackage/Engine.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/EnginePackage/Engine.json
@@ -1,0 +1,14 @@
+{
+  "name": "Engine",
+  "type": "CORE:Blueprint",
+  "extends": ["CORE:NamedEntity"],
+  "description": "",
+  "attributes": [
+    {
+      "name": "hp",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ],
+  "uiRecipes": []
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/EnginePackage/package.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/EnginePackage/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "EnginePackage",
+  "type": "CORE:Package",
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "TEST-ENGINE",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "sys"
+      }
+    ]
+  }
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/package.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "CarPackage",
+  "type": "CORE:Package",
+  "_meta_": {
+    "type": "CORE:Meta",
+    "version": "0.0.1",
+    "dependencies": [
+      {
+        "alias": "TEST",
+        "address": "system/SIMOS",
+        "version": "0.0.1",
+        "protocol": "sys"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What does this pull request change?
update add_file_to_package function to add meta info to package (and don't upload pacakge.json files to dmss)
## Why is this pull request needed?
the package.json file is used for loading meta information to a package when importing a package. Before, this package.json file was interpreted as an entity by mistake (see also issue details).
## Issues related to this change
closes #32 
