### PR TITLE
feature: support cross data source relative references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
         language_version: python3.8
         files: .*\.py$
         additional_dependencies: ["click==8.0.4"]
+        args:
+          - --line-length=119
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.6.2
@@ -34,6 +36,7 @@ repos:
       - id: isort
         name: isort (python)
         files: ^.*\.py$
+        args: [ "--profile=black"]
 
   - repo: https://github.com/pycqa/flake8
     rev: "5.0.0"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 # Data Modelling CLI Tool
 
-### Requirements
-This package requires Python 3.
+## Requirements
+This package requires Python >=3.8
 
-### Installing
+## Installing
 To install this CLI tool you can run the below command
 ```sh
 $ pip3 install dm-cli
@@ -20,7 +20,7 @@ $ pip3 install .
 
 Both the above commands would install the package globally and `dm` will be available on your system.
 
-### Usage
+## Usage
 
 ```sh
 $ dm --help
@@ -40,7 +40,7 @@ Commands:
 
 For each of the `commands` listed above, you can run `dm <COMMAND> --help` to see subcommand-specific help messages, e.g. `dm ds import --help` or `dm pkg --help`
 
-#### Expected directory structure
+### Expected directory structure
 Certain commands expect a specific directory structure, such as the commands `dm reset`, `dm init`, and `dm ds reset`.
 For these commands, the `path` argument must be the path to a directory with two subdirectories, `data_sources` and `data`.
 
@@ -57,7 +57,34 @@ app
     └── DemoApplicationDataSource.json
 ```
 
-#### General
+### Supported reference syntax
+The CLI tool will understand and resolve these kind of type reference schemas during import.
+All values with one of these keys; `("type", "attributeType", "extends", "_blueprintPath_")` will be evaluated for resolution.
+
+```bash
+# DMSS
+dmss://datasource/package/entity
+dmss://datasource/package/subfolder/entity
+
+# Alias - Require dependencies to be defined somewhere in the source tree
+ALIAS:packge/entity
+ALIAS:entity
+
+# Data Source - Relative from the destination data source
+/package/entity
+/package/subfolder/entity
+
+# Package - Relative from the source package
+entity
+subfolder/entity
+
+# TODO: Dotted - Relative from the file (UNIX directory traversal)
+./..entity
+../subfolder/entity
+../../subfolder/entity
+```
+
+### General
 Initialize the data sources
 
 *i.e. import datasources and their packages*
@@ -83,7 +110,7 @@ $ dm reset
 $ dm reset app/
 ```
 
-#### Datasources
+### Datasources
 Import a datasource
 
 ```sh
@@ -112,7 +139,7 @@ $ dm ds reset DemoApplicationDataSource
 $ dm ds reset DemoApplicationDataSource app/
 ```
 
-#### Packages
+### Packages
 Import a package
 > Note that importing a package will delete any preexisting package with the same name, if present in DMSS
 
@@ -150,7 +177,7 @@ $ dm pkg delete-all <data_source> <path>
 $ dm pkg delete-all DemoApplicationDataSource app/data/DemoApplicationDataSource
 ```
 
-### Development
+## Development
 > You need to have DMSS running locally.
 
 ```sh
@@ -160,10 +187,11 @@ $ pip3 install -e .
 $ dm init
 ```
 
-#### Testing
+### Testing
 
-1. Install the dev dependencies: `pip3 install -r dev-requirements.txt`
-2. Run the tests: `pytest`
+1. Install the dependencies: `pip3 install -r requirements.txt`
+2. Install the dev dependencies: `pip3 install -r dev-requirements.txt`
+3. Run the tests: `pytest`
 
-### Feedback
+## Feedback
 Please feel free to leave feedback in issues/PRs.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ All values with one of these keys; `("type", "attributeType", "extends", "_bluep
 
 ```bash
 # DMSS
-dmss://datasource/package/entity
-dmss://datasource/package/subfolder/entity
+sys://datasource/package/entity
+sys://datasource/package/subfolder/entity
 
 # Alias - Require dependencies to be defined somewhere in the source tree
 ALIAS:packge/entity

--- a/dm_cli/application.py
+++ b/dm_cli/application.py
@@ -19,9 +19,7 @@ def _parse_alias_file(file_path: str) -> Dict[str, str]:
                 if line.lstrip()[0] == "#":  # Skip commented lines
                     continue
                 if not re.search(pattern, line):
-                    raise ValueError(
-                        f"The alias file '{file_path}' is invalid. Invalid line '{line}'"
-                    )
+                    raise ValueError(f"The alias file '{file_path}' is invalid. Invalid line '{line}'")
                 key, value = line.split("=", 1)
                 result[key] = value
 
@@ -73,15 +71,11 @@ def _load_app_settings(home: str):
             with open(f"{home}/{app}/settings.json") as json_file:
                 app_settings: dict = json.load(json_file)
                 app_settings["fileLocation"] = json_file.name
-                app_settings["dataSourceAliases"] = _parse_alias_file(
-                    f"{home}/{app}/data/_aliases_"
-                )
+                app_settings["dataSourceAliases"] = _parse_alias_file(f"{home}/{app}/data/_aliases_")
                 code_gen_folder = Path(f"{home}/{app}/code_generators")
                 if code_gen_folder.is_dir():
                     app_settings["codeGenerators"] = os.listdir(str(code_gen_folder))
-                application_settings[
-                    app_settings["name"]
-                ] = _replace_aliases_in_settings(app_settings)
+                application_settings[app_settings["name"]] = _replace_aliases_in_settings(app_settings)
         except FileNotFoundError:
             raise FileNotFoundError(
                 f"No settings file found for the app '{app}'."
@@ -89,9 +83,7 @@ def _load_app_settings(home: str):
                 f"'{home}/{{name-of-app}}/'"
             )
         except KeyError as e:
-            raise KeyError(
-                f"The settings file for the '{app}' application is invalid: {e}"
-            )
+            raise KeyError(f"The settings file for the '{app}' application is invalid: {e}")
         print(f"Successfully loaded app '{app}'")
 
     return application_settings
@@ -122,11 +114,7 @@ def get_app_dir_structure(path: Path) -> [Path, Path]:
 
 def get_data_source_definition_files(path: Path) -> List[str]:
     """Get all JSON files found in <path>."""
-    return [
-        filename
-        for filename in os.listdir(path)
-        if filename.endswith(f".{DATA_SOURCE_DEF_FILE_EXT}")
-    ]
+    return [filename for filename in os.listdir(path) if filename.endswith(f".{DATA_SOURCE_DEF_FILE_EXT}")]
 
 
 def get_subdirectories(path: Path) -> List[str]:

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -17,9 +17,9 @@ from dm_cli.application import (
     DATA_SOURCE_DEF_FILE_EXT,
 )
 from dm_cli.dmss import dmss_api
-from dmss_api.exceptions import ApiException
-from dm_cli.import_package import (ApplicationException, import_package_tree)
-from package_tree_from_zip import package_tree_from_zip
+from dm_cli.import_package import import_package_tree
+from dm_cli.utils import ApplicationException
+from dm_cli.package_tree_from_zip import package_tree_from_zip
 from dm_cli.zip_all import zip_all
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -18,8 +18,8 @@ from dm_cli.application import (
 )
 from dm_cli.dmss import dmss_api
 from dmss_api.exceptions import ApiException
-from dm_cli.import_package import (ApplicationException, import_package_tree,
-                                package_tree_from_zip)
+from dm_cli.import_package import (ApplicationException, import_package_tree)
+from package_tree_from_zip import package_tree_from_zip
 from dm_cli.zip_all import zip_all
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])

--- a/dm_cli/domain.py
+++ b/dm_cli/domain.py
@@ -27,9 +27,7 @@ class Package:
         return self.__getattribute__(item)
 
     def search(self, filename: str) -> Union["Package", dict]:
-        return next(
-            (child for child in self.content if child["name"] == filename), None
-        )
+        return next((child for child in self.content if child["name"] == filename), None)
 
     def to_dict(self):
         return {
@@ -42,9 +40,7 @@ class Package:
             "content": self._content_to_ref_dict(),
         }
 
-    def traverse_documents(
-        self, func: Callable, update: bool = False, **kwargs
-    ) -> None:
+    def traverse_documents(self, func: Callable, update: bool = False, **kwargs) -> None:
         """
         Traverses the Package structure, calling the passed function on every non-Package node.
 
@@ -105,7 +101,5 @@ class Package:
                     )
 
                 else:
-                    result.append(
-                        {"_id": child["_id"], "type": child["type"], "contained": True}
-                    )
+                    result.append({"_id": child["_id"], "type": child["type"], "contained": True})
         return result

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -1,9 +1,7 @@
 import io
-import json
-from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
-from uuid import UUID, uuid4
+from typing import Dict, List, Union
+from uuid import uuid4
 from zipfile import ZipFile
 
 from progress.bar import IncrementalBar
@@ -11,174 +9,46 @@ from progress.bar import IncrementalBar
 from .dmss import dmss_api
 from .domain import Package
 from .enums import SIMOS
+from .utils import Dependency, resolve_reference
 
-
-class ApplicationException(Exception):
-    status: int = 500
-    type: str = "ApplicationException"
-    message: str = "The requested operation failed"
-    debug: str = "An unknown and unhandled exception occurred in the API"
-    data: dict = None
-
-    def __init__(
-        self,
-        message: str = "The requested operation failed",
-        debug: str = "An unknown and unhandled exception occurred in the API",
-        data: dict = None,
-        status: int = 500,
-    ):
-        self.status = status
-        self.type = self.__class__.__name__
-        self.message = message
-        self.debug = debug
-        self.data = data
-
-    def dict(self):
-        return {
-            "status": self.status,
-            "type": self.type,
-            "message": self.message,
-            "debug": self.debug,
-            "data": self.data,
-        }
-
-
-from dataclasses import dataclass
-from typing import Literal, NewType
-
-TDependencyProtocol = NewType("TDependencyProtocol", Literal["sys", "http"])
-
-
-@dataclass(frozen=True)
-class Dependency:
-    """Class for any dependencies (external types) a entity references"""
-
-    alias: str
-    # Different ways we support to fetch dependencies.
-    # sys: Internally within the DMSS instance
-    # http: A public HTTP GET call
-    protocol: TDependencyProtocol
-    address: str
-    version: str = ""
-
-    def __eq__(self, other):
-        return (
-            self.alias == other.alias
-            and self.protocol == other.protocol
-            and self.address == other.address
-            and self.version == other.version
-        )
-
-
-keys_to_check = (
-    "type",
-    "attributeType",
-    "_id",
-    "extends",
-)  # These keys may contain a reference
-
-
-def resolve_dependency(type_ref: str, dependencies: Dict[str, Dependency]) -> str:
-    """Takes a type reference and dependencies. Returns the address for
-    the Blueprint, prefixed with which protocol should be used to fetch it.
-    Expected format is ALIAS:ADDRESS"""
-    tag, path = type_ref.split(":", 1)
-    path = path.strip(" /")
-    dependency = dependencies.get(tag)
-    if not dependency:
-        raise ApplicationException(
-            f"No dependency with alias '{tag}' was found in the entities dependencies list"
-        )
-    address = dependency.address.strip(" /")
-
-    if dependency.protocol == "sys":
-        return f"sys://{address}/{path}"
-    if dependency.protocol == "http":
-        return f"http://{address}/{path}"
-
-    raise ApplicationException(
-        f"Protocol '{dependency.protocol}' is not a valid protocol for resolving dependencies"
-    )
+keys_to_check = ("type", "attributeType", "extends", "_blueprintPath_")  # These keys may contain a reference
 
 
 def replace_relative_references(
     key: str,
     value,
     dependencies: Dict[str, Dependency],
-    reference_table: dict = None,
+    data_source: str,
+    root_package: str,
     zip_file: ZipFile = None,
-) -> Any:
+) -> Union[str, List[str], dict]:
     """
-    Takes a key-value pair and returns the passed value, with relative references updated with absolute ones found in the 'reference_table'.
+    Takes a key-value pair and returns the passed value, with relative references updated with absolute ones.
 
     For Blob-entities. Insert the binary data from the file into the entity.
     It digs down on complex types.
 
-    @param reference_table: A dict like so; {"fileName": {"id": newUUID, "absolute": ds/root-package/file}
     @param key: Name of the attribute being checked in the document
     @param value: Value of the attribute being checked in the document
     @return: The passed value, with relative references updated with absolute ones
     """
     if key in keys_to_check:
-        if key == "_id":
-            try:
-                UUID(value)  # If _id is a valid uuid, don't change it
-                return value
-            except ValueError:  # The _id is not a UUID. It should then be an alias
-                try:
-                    return next(
-                        (
-                            doc["id"]
-                            for doc in reference_table.values()
-                            if doc["alias"] == value
-                        )
-                    )
-                except StopIteration:
-                    raise ApplicationException(
-                        f"IMPORT ERROR: No document with the alias '{value}' was found in the reference table."
-                    )
         if key == "extends":  # 'extends' is a list
             extends_list = []
             for i, blueprint in enumerate(value):
-                if ":" in blueprint:
-                    extends_list.append(resolve_dependency(blueprint, dependencies))
-                    continue
-                # Relative references start with a "/", if not, they are absolute references
-                if blueprint[0] == "/":
-                    try:
-                        extends_list.append(reference_table[value[i]]["absolute"])
-                    except KeyError:
-                        raise ApplicationException(
-                            "Import failed",
-                            debug=f"Failed to find the relative reference '{value[i]}' in the reference table.",
-                            data=value,
-                        )
-                    continue
-                extends_list.append(blueprint)
+                extends_list.append(resolve_reference(blueprint, dependencies, data_source, root_package))
             return extends_list
-        if ":" in value:
-            return resolve_dependency(value, dependencies)
-        if value[0] == "/":
-            try:
-                return reference_table[value]["absolute"]
-            except KeyError:
-                raise ApplicationException(
-                    f"IMPORT ERROR: Failed to find the relative reference '{value}' in the reference table."
-                )
+        return resolve_reference(value, dependencies, data_source, root_package)
 
     # If the value is a complex type, dig down recursively. Ignore the _meta_ key.
     if key != "_meta_" and isinstance(value, dict) and value != {}:
         # First check if the type is a blob type
         if (
-            replace_relative_references(
-                "type", value["type"], dependencies, reference_table, zip_file
-            )
+            replace_relative_references("type", value["type"], dependencies, data_source, root_package, zip_file)
             == SIMOS.BLOB.value
         ):
             # Add blob data to the blob-entity
-            if (
-                value["name"][0] == "/"
-            ):  # It's a relative reference to the blob file. Get root_package_name...
+            if value["name"][0] == "/":  # It's a relative reference to the blob file. Get root_package_name...
                 root_package_name = f"{zip_file.filelist[0].filename.split('/', 1)[0]}"
                 # '_blob_data' is a temporary key for keeping the binary data
                 return {
@@ -190,42 +60,27 @@ def replace_relative_references(
             return {"_blob_data_": zip_file.read(value["name"]), **value}
 
         return {
-            k: replace_relative_references(
-                k, v, dependencies, reference_table, zip_file
-            )
+            k: replace_relative_references(k, v, dependencies, data_source, root_package, zip_file)
             for k, v in value.items()
         }
     if isinstance(value, list):
-        return [
-            replace_relative_references(key, v, dependencies, reference_table, zip_file)
-            for v in value
-        ]
+        return [replace_relative_references(key, v, dependencies, data_source, root_package, zip_file) for v in value]
 
-    return (
-        value  # This means it's a primitive type with an absolute path, return it as is
-    )
+    # This means it's a primitive type or an absolute path, return it as is
+    return value
 
 
-def add_file_to_package(
-    path: Path, package: Package, document: dict
-) -> Tuple[UUID, str]:
+def add_file_to_package(path: Path, package: Package, document: dict) -> None:
     if len(path.parts) == 1:  # End of path means the actual document
-        uid = uuid4()
-        # If the document has an "_id", return it as an alias, if not use UUID as alias.
-        alias = document.get("_id", str(uid))
-        package.content.append({**document, "_id": alias})
-        return uid, alias
-
+        # Create a UUID if the document does not have one
+        package.content.append({**document, "_id": document.get("_id", str(uuid4()))})
+        return
     sub_folder = next((p for p in package.content if p["name"] == path.parts[0]), None)
-    if (
-        not sub_folder
-    ):  # If the sub folder has not already been created on parent, create it
+    if not sub_folder:  # If the sub folder has not already been created on parent, create it
         sub_folder = Package(name=path.parts[0])
         package.content.append(sub_folder)
 
-    new_path = str(path).split("/", 1)[
-        1
-    ]  # Remove first element in path before stepping down
+    new_path = str(path).split("/", 1)[1]  # Remove first element in path before stepping down
     return add_file_to_package(Path(new_path), sub_folder, document)
 
 
@@ -235,128 +90,12 @@ def add_package_to_package(path: Path, package: Package) -> None:
         return
 
     sub_folder = next((p for p in package.content if p["name"] == path.parts[0]), None)
-    if (
-        not sub_folder
-    ):  # If the sub folder has not already been created on parent, create it
+    if not sub_folder:  # If the sub folder has not already been created on parent, create it
         sub_folder = Package(name=path.parts[0])
         package.content.append(sub_folder)
 
-    new_path = str(path).split("/", 1)[
-        1
-    ]  # Remove first element in path before stepping down
+    new_path = str(path).split("/", 1)[1]  # Remove first element in path before stepping down
     return add_package_to_package(Path(new_path), sub_folder)
-
-
-def package_tree_from_zip(data_source_id: str, zip_package: io.BytesIO) -> Package:
-    """
-    Converts a Zip-folder into a DMSS Package structure.
-
-    Inserting UUID4's between any references, converting relative paths to absolute paths,
-    and dependencyAliases to absolute addresses.
-
-    @param data_source_id: A string with the name/id of an existing data source to import package to
-    @param zip_package: A zip-folder represented as an in-memory io.BytesIO object
-    @return: A Package object with sub folders(Package) and documents(dict)
-    """
-    reference_table = {}
-
-    with ZipFile(zip_package) as zip_file:
-        folder_name = zip_file.filelist[0].filename.split("/", 1)[0]
-
-        # Find the root packages package.json file
-        package_file = next(
-            (
-                z
-                for z in zip_file.filelist
-                if z.filename == f"{folder_name}/package.json"
-            ),
-            None,
-        )
-
-        package_entity = (
-            json.loads(zip_file.read(package_file.filename)) if package_file else {}
-        )
-        dependencies: Dict[str, Dependency] = {}
-        root_package = Package(
-            name=package_entity.get("name", folder_name),
-            is_root=True,
-            meta=package_entity.get("_meta_"),
-        )
-        # Construct a nested Package object of the package to import
-        for file_info in zip_file.filelist:
-            filename = file_info.filename.split("/", 1)[1]  # Remove RootPackage prefix
-            if file_info.is_dir():
-                if filename == "":  # Skip rootPackage
-                    continue
-                add_package_to_package(Path(filename), root_package)
-                continue
-            if Path(filename).suffix != ".json":
-                continue
-            try:
-                json_doc = json.loads(zip_file.read(f"{folder_name}/{filename}"))
-            except JSONDecodeError:
-                raise Exception(
-                    f"Failed to load the file '{filename}' as a JSON document"
-                )
-            uid, alias = add_file_to_package(Path(filename), root_package, json_doc)
-
-            # Add dependencies from entity to the global dependencies list
-            entity_dependencies = {
-                v["alias"]: Dependency(**v)
-                for v in json_doc.get("_meta_", {}).get("dependencies", [])
-            }
-            alias_intersect = entity_dependencies.keys() & dependencies.keys()
-
-            # If there are duplicated aliases, raise error if they are not identical to the existing one
-            for duplicated_alias in alias_intersect:
-                if (
-                    entity_dependencies[duplicated_alias]
-                    != dependencies[duplicated_alias]
-                ):
-                    raise ApplicationException(
-                        f"Conflicting dependency alias(es) in file '{filename}'. '{alias_intersect}'"
-                    )
-            dependencies.update(entity_dependencies)
-
-            # Use the "name" attribute as the last element in the
-            # reference path, so filename and "name" don't need to match
-            if "name" in json_doc:
-                if "/" in filename:
-                    relative_path = (
-                        f"/{'/'.join(filename.split('/')[:-1])}/{json_doc['name']}"
-                    )
-                else:
-                    relative_path = f"/{json_doc['name']}"
-            else:
-                relative_path = f"/{filename}"
-            # Create a dict with new UUID's and absolute references for every file in the package
-            reference_table.update(
-                {
-                    relative_path: {
-                        "filename": filename,
-                        "alias": alias,
-                        "id": str(uid),
-                        "absolute": f"sys://{data_source_id}/{package_entity.get('name', folder_name)}{relative_path}",
-                    }
-                }
-            )
-
-        # Now that we have the entire package as a Package tree, traverse it, and replace relative references
-        root_package.traverse_documents(
-            lambda document: {
-                key: replace_relative_references(
-                    key,
-                    value,
-                    dependencies,
-                    reference_table=reference_table,
-                    zip_file=zip_file,
-                )
-                for key, value in document.items()
-            },
-            update=True,
-        )
-
-    return root_package
 
 
 def upload_blobs_in_document(document: dict, data_source_id: str) -> dict:
@@ -376,33 +115,22 @@ def upload_blobs_in_document(document: dict, data_source_id: str) -> dict:
             }
     except KeyError as error:
         reduced_document = {k: v for k, v in document.items() if isinstance(v, str)}
-        raise KeyError(
-            f"The document; '{reduced_document}' is missing a required attribute: {error}"
-        )
+        raise KeyError(f"The document; '{reduced_document}' is missing a required attribute: {error}")
     for key, value in document.items():
-        if (
-            key == "_meta_"
-        ):  # meta data can never contain blob data. Skip for performance
+        if key == "_meta_":  # meta data can never contain blob data. Skip for performance
             return document
         if isinstance(value, dict) and value:
             document[key] = upload_blobs_in_document(value, data_source_id)
         if isinstance(value, list) and value:
             if len(value) > 0 and isinstance(value[0], dict):
-                document[key] = [
-                    upload_blobs_in_document(item, data_source_id)
-                    for item in document[key]
-                ]
+                document[key] = [upload_blobs_in_document(item, data_source_id) for item in document[key]]
     return document
 
 
 def import_package_tree(root_package: Package, data_source_id: str) -> None:
     documents_to_upload: List[dict] = [root_package.to_dict()]
-    root_package.traverse_documents(
-        lambda document: documents_to_upload.append(document)
-    )
-    root_package.traverse_package(
-        lambda package: documents_to_upload.append(package.to_dict())
-    )
+    root_package.traverse_documents(lambda document: documents_to_upload.append(document))
+    root_package.traverse_package(lambda package: documents_to_upload.append(package.to_dict()))
 
     with IncrementalBar(
         f"\tImporting {root_package.name}",

--- a/dm_cli/package_tree_from_zip.py
+++ b/dm_cli/package_tree_from_zip.py
@@ -1,0 +1,84 @@
+import io
+import json
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Dict
+from zipfile import ZipFile
+
+from .domain import Package
+from .import_package import (
+    add_file_to_package,
+    add_package_to_package,
+    replace_relative_references,
+)
+from .utils import Dependency, concat_dependencies
+
+
+def package_tree_from_zip(data_source_id: str, zip_package: io.BytesIO) -> Package:
+    """
+    Converts a Zip-folder into a DMSS Package structure.
+
+    Inserting UUID4's between any references, converting relative paths to absolute paths,
+    and dependencyAliases to absolute addresses.
+
+    @param data_source_id: A string with the name/id of an existing data source to import package to
+    @param zip_package: A zip-folder represented as an in-memory io.BytesIO object
+    @return: A Package object with sub folders(Package) and documents(dict)
+    """
+    reference_table = {}
+
+    with ZipFile(zip_package) as zip_file:
+        folder_name = zip_file.filelist[0].filename.split("/", 1)[0]
+
+        # Find the root packages package.json file
+        package_file = next(
+            (z for z in zip_file.filelist if z.filename == f"{folder_name}/package.json"),
+            None,
+        )
+
+        package_entity = json.loads(zip_file.read(package_file.filename)) if package_file else {}
+        dependencies: Dict[str, Dependency] = {}
+        root_package = Package(
+            name=package_entity.get("name", folder_name),
+            is_root=True,
+            meta=package_entity.get("_meta_"),
+        )
+        # Construct a nested Package object of the package to import
+        for file_info in zip_file.filelist:
+            filename = file_info.filename.split("/", 1)[1]  # Remove RootPackage prefix
+            if file_info.is_dir():
+                if filename == "":  # Skip rootPackage
+                    continue
+                add_package_to_package(Path(filename), root_package)
+                continue
+            if Path(filename).suffix != ".json":
+                continue
+            try:
+                json_doc = json.loads(zip_file.read(f"{folder_name}/{filename}"))
+            except JSONDecodeError:
+                raise Exception(f"Failed to load the file '{filename}' as a JSON document")
+
+            add_file_to_package(Path(filename), root_package, json_doc)
+
+            # Add dependencies from entity to the global dependencies list
+            dependencies = concat_dependencies(
+                json_doc.get("_meta_", {}).get("dependencies", []), dependencies, filename
+            )
+
+        # Now that we have the entire package as a Package tree, traverse it, and replace relative references
+        root_package.traverse_documents(
+            lambda document: {
+                key: replace_relative_references(
+                    key,
+                    value,
+                    dependencies,
+                    zip_file=zip_file,
+                    data_source=data_source_id,
+                    root_package=root_package.name,
+                )
+                for key, value in document.items()
+            },
+            update=True,
+        )
+
+    return root_package

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import Dict, List, Literal, NewType
+
+
+class ApplicationException(Exception):
+    status: int = 500
+    type: str = "ApplicationException"
+    message: str = "The requested operation failed"
+    debug: str = "An unknown and unhandled exception occurred in the API"
+    data: dict = None
+
+    def __init__(
+        self,
+        message: str = "The requested operation failed",
+        debug: str = "An unknown and unhandled exception occurred in the API",
+        data: dict = None,
+        status: int = 500,
+    ):
+        self.status = status
+        self.type = self.__class__.__name__
+        self.message = message
+        self.debug = debug
+        self.data = data
+
+    def dict(self):
+        return {
+            "status": self.status,
+            "type": self.type,
+            "message": self.message,
+            "debug": self.debug,
+            "data": self.data,
+        }
+
+
+TDependencyProtocol = NewType("TDependencyProtocol", Literal["sys", "http"])
+
+
+@dataclass(frozen=True)
+class Dependency:
+    """Class for any dependencies (external types) a entity references"""
+
+    alias: str
+    # Different ways we support to fetch dependencies.
+    # sys: Internally within the DMSS instance
+    # http: A public HTTP GET call
+    protocol: TDependencyProtocol
+    address: str
+    version: str = ""
+
+    def __eq__(self, other):
+        return (
+            self.alias == other.alias
+            and self.protocol == other.protocol
+            and self.address == other.address
+            and self.version == other.version
+        )
+
+
+def find_reference_schema(reference: str) -> Literal["dmss", "alias", "dotted", "package", "data_source"]:
+    if "://" in reference:
+        return "dmss"
+    if ":" in reference:
+        return "alias"
+    if "." in reference:
+        return "dotted"
+    if reference[0] == "/":
+        return "data_source"
+    return "package"
+
+
+def resolve_dependency(type_ref: str, dependencies: Dict[str, Dependency]) -> str:
+    """Takes a type reference and dependencies. Returns the address for
+    the Blueprint, prefixed with which protocol should be used to fetch it.
+    Expected format is ALIAS:ADDRESS"""
+    tag, path = type_ref.split(":", 1)
+    path = path.strip(" /")
+    dependency = dependencies.get(tag)
+    if not dependency:
+        raise ApplicationException(f"No dependency with alias '{tag}' was found in the entities dependencies list")
+    address = dependency.address.strip(" /")
+
+    if dependency.protocol == "sys":
+        return f"sys://{address}/{path}"
+    if dependency.protocol == "http":
+        return f"http://{address}/{path}"
+
+    raise ApplicationException(f"Protocol '{dependency.protocol}' is not a valid protocol for resolving dependencies")
+
+
+def resolve_reference(reference: str, dependencies: Dict[str, Dependency], data_source: str, root_package: str) -> str:
+    ref_schema = find_reference_schema(reference)
+    if ref_schema == "alias":
+        return resolve_dependency(reference, dependencies)
+    if ref_schema == "data_source":
+        return f"sys://{data_source}{reference}"
+    if ref_schema == "package":
+        return f"sys://{data_source}/{root_package}/{reference}"
+    if ref_schema in "dotted":
+        raise NotImplementedError(f"Dotted relative references is not yet supported. Got: '{reference}'")
+
+
+def concat_dependencies(
+    new_dependencies: List[dict], old_dependencies: Dict[str, Dependency], filename: str
+) -> Dict[str, Dependency]:
+    entity_dependencies = {v["alias"]: Dependency(**v) for v in new_dependencies}
+    alias_intersect = entity_dependencies.keys() & old_dependencies.keys()
+
+    # If there are duplicated aliases, raise error if they are not identical to the existing one
+    for duplicated_alias in alias_intersect:
+        if entity_dependencies[duplicated_alias] != old_dependencies[duplicated_alias]:
+            raise ApplicationException(f"Conflicting dependency alias(es) in file '{filename}'. '{alias_intersect}'")
+    old_dependencies.update(entity_dependencies)
+    return old_dependencies

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.15",
+    version="0.1.16",
     author="",
     author_email="",
     license="MIT",

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
@@ -24,7 +24,7 @@
     {
       "name": "wheels",
       "type": "CORE:BlueprintAttribute",
-      "attributeType": "/CarPackage/Wheel",
+      "attributeType": "CarPackage/Wheel",
       "dimensions": "*"
     }
   ],

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExtendsRelative.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExtendsRelative.json
@@ -1,7 +1,7 @@
 {
   "name": "ExtendedApplication",
   "type": "CORE:Blueprint",
-  "extends": ["/DemoApplication"],
+  "extends": ["DemoApplication"],
   "description": "",
   "attributes": [
     {
@@ -13,7 +13,7 @@
     {
       "name": "wheels",
       "type": "CORE:BlueprintAttribute",
-      "attributeType": "/CarPackage/Wheel",
+      "attributeType": "CarPackage/Wheel",
       "dimensions": "*",
       "optional": false
     }


### PR DESCRIPTION
## What does this pull request change?
- support _cross package relative references_
- added documentation on supported reference formats
- added "\_blueprintPath\_" as a keyword for values to resolve
- use the "black" profile for isort pre-commit hook to avoid conflicts with black
- set black line width to 119

REGRESSION: We can no longer use "_id" placeholders for entity id's. _id is not handled in any special way, and need to be "correct" on disk.

## Issues related to this change

closes #40