### PR TITLE
Feat/download documents from dmss

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ Exporting packages and single documents
 $ dm pkg export <data_source>/<path>
 $ dm pkg export <data_source>/<path> <destination_path>
 $ dm pkg export <data_source>/<path> <destination_path> --unpack
-$ dm pkg export <data_source>/<path> <destination_path> --unpack -overwrite
 
 # Export all documents in 'DemoApplicationDataSource/models/CarPackage'
 $ dm pkg export DemoApplicationDataSource/models/CarPackage
@@ -179,7 +178,6 @@ $ dm pkg export DemoApplicationDataSource/models/CarPackage
 Optional arguments and flags:
 <destination_path> : specifies where to save the downloaded file(s) on the local disk
 unpack: whether or not to unpack the zip file
-overwrite: wheter or not to overwrite folder/file on local disk if it exists
 
 Delete a package
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,22 @@ $ dm pkg import-all app/data/DemoApplicationDataSource DemoApplicationDataSource
 ```
 
 
-Exporting document(s) in a package as a zip file
+Exporting packages and single documents
 ```sh
-# export document(s) in a package in the directory given by <path>
-$ dm pkg export <path> <data_source>
-# Export all documents in 'app/data/DemoApplicationDataSource'
-$ dm pkg export app/data/DemoApplicationDataSource DemoApplicationDataSource
+# export document(s) by a given <data_source>/<path>
+$ dm pkg export <data_source>/<path>
+$ dm pkg export <data_source>/<path> <destination_path>
+$ dm pkg export <data_source>/<path> <destination_path> --unpack
+$ dm pkg export <data_source>/<path> <destination_path> --unpack -override
+
+# Export all documents in 'DemoApplicationDataSource/models/CarPackage'
+$ dm pkg export DemoApplicationDataSource/models/CarPackage
 ```
+
+Optional arguments and flags:
+<destination_path> : specifies where to save the downloaded file(s) on the local disk
+unpack: whether or not to unpack the zip file
+override: wheter or not to override folder/file on local disk if it exists
 
 Delete a package
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Exporting packages and single documents
 $ dm pkg export <data_source>/<path>
 $ dm pkg export <data_source>/<path> <destination_path>
 $ dm pkg export <data_source>/<path> <destination_path> --unpack
-$ dm pkg export <data_source>/<path> <destination_path> --unpack -override
+$ dm pkg export <data_source>/<path> <destination_path> --unpack -overwrite
 
 # Export all documents in 'DemoApplicationDataSource/models/CarPackage'
 $ dm pkg export DemoApplicationDataSource/models/CarPackage
@@ -179,7 +179,7 @@ $ dm pkg export DemoApplicationDataSource/models/CarPackage
 Optional arguments and flags:
 <destination_path> : specifies where to save the downloaded file(s) on the local disk
 unpack: whether or not to unpack the zip file
-override: wheter or not to override folder/file on local disk if it exists
+overwrite: wheter or not to overwrite folder/file on local disk if it exists
 
 Delete a package
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ $ dm pkg import-all <path> <data_source>
 $ dm pkg import-all app/data/DemoApplicationDataSource DemoApplicationDataSource
 ```
 
+
+Exporting document(s) in a package as a zip file
+```sh
+# export document(s) in a package in the directory given by <path>
+$ dm pkg export <path> <data_source>
+# Export all documents in 'app/data/DemoApplicationDataSource'
+$ dm pkg export app/data/DemoApplicationDataSource DemoApplicationDataSource
+```
+
 Delete a package
 
 ```sh

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -243,8 +243,10 @@ def export_documents(context, absolute_document_reference: str, export_location:
         zip_file.filename = f"{absolute_document_reference.split('/')[-1]}.zip"
         if unpack:
             unpack_and_save_zipfile(override=override, export_location=export_location, zip_file=zip_file)
+            click.echo("Unpacked and saved zip file!")
         else:
             save_as_zip_file(override=override, export_location=export_location, filename=zip_file.filename, data=response.content)
+            click.echo("Saved zip file!")
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")
 @click.argument("data_source", required=True)

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -222,9 +222,9 @@ def import_packages(context, path: str, data_source: str):
 @click.argument("absolute_document_reference", required=True)
 @click.argument("export_location", required=False, default="")
 @click.option("-u", "--unpack", is_flag=True, help="Flag to determine if the downloaded zip should be unpacked.")
-@click.option("-o", "--override", is_flag=True, help="If flag is set, existing folder/document with the same name as the downloaded folder/document will be overwritten.")
+@click.option("-o", "--overwrite", is_flag=True, help="If flag is set, existing folder/document with the same name as the downloaded folder/document will be overwritten.")
 @click.pass_context
-def export_documents(context, absolute_document_reference: str, export_location: str = "", unpack: bool = False, override: bool = False):
+def export_documents(context, absolute_document_reference: str, export_location: str = "", unpack: bool = False, overwrite: bool = False):
     """
     export document(s) by a given <data_source>/<path>
 
@@ -242,10 +242,10 @@ def export_documents(context, absolute_document_reference: str, export_location:
     with ZipFile(io.BytesIO(response.content), "r") as zip_file:
         zip_file.filename = f"{absolute_document_reference.split('/')[-1]}.zip"
         if unpack:
-            unpack_and_save_zipfile(override=override, export_location=export_location, zip_file=zip_file)
+            unpack_and_save_zipfile(overwrite=overwrite, export_location=export_location, zip_file=zip_file)
             click.echo("Unpacked and saved zip file!")
         else:
-            save_as_zip_file(override=override, export_location=export_location, filename=zip_file.filename, data=response.content)
+            save_as_zip_file(overwrite=overwrite, export_location=export_location, filename=zip_file.filename, data=response.content)
             click.echo("Saved zip file!")
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -243,10 +243,8 @@ def export_documents(context, absolute_document_reference: str, export_location:
         zip_file.filename = f"{absolute_document_reference.split('/')[-1]}.zip"
         if unpack:
             unpack_and_save_zipfile(overwrite=overwrite, export_location=export_location, zip_file=zip_file)
-            click.echo("Unpacked and saved zip file!")
         else:
             save_as_zip_file(overwrite=overwrite, export_location=export_location, filename=zip_file.filename, data=response.content)
-            click.echo("Saved zip file!")
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")
 @click.argument("data_source", required=True)

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -222,14 +222,15 @@ def import_packages(context, path: str, data_source: str):
 @click.argument("absolute_document_reference", required=True)
 @click.argument("export_location", required=False, default="")
 @click.option("-u", "--unpack", is_flag=True, help="Flag to determine if the downloaded zip should be unpacked.")
-@click.option("-o", "--overwrite", is_flag=True, help="If flag is set, existing folder/document with the same name as the downloaded folder/document will be overwritten.")
 @click.pass_context
-def export_documents(context, absolute_document_reference: str, export_location: str = "", unpack: bool = False, overwrite: bool = False):
+def export_documents(context, absolute_document_reference: str, export_location: str = "", unpack: bool = False):
     """
     export document(s) by a given <data_source>/<path>
 
     Example: if you have a data_source "DemoApplicationDataSource" with the root package "models" and a sub package "Windmill",
     the entire "Windmill" package can be exported using: absolute_document_reference = "DemoApplicationDataSource/models/Windmill"
+
+    If the file or folder to export already exists on local disk, an exception is raised.
 
     Arguments:
     absolute_document_reference: Path to document or package to export. Should be <dataSource>/<path>
@@ -242,9 +243,9 @@ def export_documents(context, absolute_document_reference: str, export_location:
     with ZipFile(io.BytesIO(response.content), "r") as zip_file:
         zip_file.filename = f"{absolute_document_reference.split('/')[-1]}.zip"
         if unpack:
-            unpack_and_save_zipfile(overwrite=overwrite, export_location=export_location, zip_file=zip_file)
+            unpack_and_save_zipfile(export_location=export_location, zip_file=zip_file)
         else:
-            save_as_zip_file(overwrite=overwrite, export_location=export_location, filename=zip_file.filename, data=response.content)
+            save_as_zip_file(export_location=export_location, filename=zip_file.filename, data=response.content)
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")
 @click.argument("data_source", required=True)

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -6,10 +6,10 @@ import json
 import traceback
 from pathlib import Path
 from zipfile import ZipFile
-
 import click
 import emoji
 
+from dm_cli.dmss import settings, export
 from dm_cli.application import (
     get_app_dir_structure,
     get_data_source_definition_files,
@@ -17,7 +17,7 @@ from dm_cli.application import (
     DATA_SOURCE_DEF_FILE_EXT,
 )
 from dm_cli.dmss import dmss_api
-from dmss_api.exceptions import ApiException
+from dm_cli.dmss_api.exceptions import ApiException
 from dm_cli.import_package import import_package_tree
 from dm_cli.utils import ApplicationException
 from dm_cli.package_tree_from_zip import package_tree_from_zip
@@ -41,8 +41,10 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 def cli(context, token: str, url: str):
     # Set the auth header
     dmss_api.api_client.default_headers["Authorization"] = f"Bearer {token}"
+    settings.DMSS_TOKEN = token
     # Set the DMSS host
     dmss_api.api_client.configuration.host = url
+    settings.PUBLIC_DMSS_API = url
 
 
 @cli.group("ds", help="Subcommand for working with data sources")
@@ -214,6 +216,28 @@ def import_packages(context, path: str, data_source: str):
         for r in results:
             if not r:
                 exit(1)  # If any of the parallel functions did not return True, they fail, and so we exit with 1
+
+
+@pkg_cli.command("export", help="Export document(s) in a package as a zip file in the directory given by <path> for a data source.")
+@click.argument("path", required=True)
+@click.argument("data_source", required=True)
+@click.pass_context
+def export_documents(context, path: str, data_source: str):
+    """
+    Export document(s) in a package. path is relative to the data_source.
+
+    Example: if you have the root package "models" with a sub package Windmill in the data_source DemoApplicationDataSource,
+    the entire Windmill package can be exported using:
+    path = "models/Windmill"
+    data_source = "DemoApplicationDataSource"
+
+    The zip file is downloaded to the directory the command is called from.
+    """
+    # path and data_source should not have a trailing or leading "/"
+    path = path.rstrip("/").lstrip("/")
+    data_source = data_source.rstrip("/").lstrip("/")
+
+    export(absolute_document_ref=f"{data_source}/{path}")
 
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
-
-import concurrent.futures
 import io
+import concurrent.futures
 import json
+import os
 import traceback
 from pathlib import Path
 from zipfile import ZipFile
@@ -19,7 +19,7 @@ from dm_cli.application import (
 from dm_cli.dmss import dmss_api
 from dm_cli.dmss_api.exceptions import ApiException
 from dm_cli.import_package import import_package_tree
-from dm_cli.utils import ApplicationException
+from dm_cli.utils import ApplicationException, unpack_and_save_zipfile, save_as_zip_file
 from dm_cli.package_tree_from_zip import package_tree_from_zip
 from dm_cli.zip_all import zip_all
 
@@ -218,27 +218,33 @@ def import_packages(context, path: str, data_source: str):
                 exit(1)  # If any of the parallel functions did not return True, they fail, and so we exit with 1
 
 
-@pkg_cli.command("export", help="Export document(s) in a package as a zip file in the directory given by <path> for a data source.")
-@click.argument("path", required=True)
-@click.argument("data_source", required=True)
+@pkg_cli.command("export")
+@click.argument("absolute_document_reference", required=True)
+@click.argument("export_location", required=False, default="")
+@click.option("-u", "--unpack", is_flag=True, help="Flag to determine if the downloaded zip should be unpacked.")
+@click.option("-o", "--override", is_flag=True, help="If flag is set, existing folder/document with the same name as the downloaded folder/document will be overwritten.")
 @click.pass_context
-def export_documents(context, path: str, data_source: str):
+def export_documents(context, absolute_document_reference: str, export_location: str = "", unpack: bool = False, override: bool = False):
     """
-    Export document(s) in a package. path is relative to the data_source.
+    export document(s) by a given <data_source>/<path>
 
-    Example: if you have the root package "models" with a sub package Windmill in the data_source DemoApplicationDataSource,
-    the entire Windmill package can be exported using:
-    path = "models/Windmill"
-    data_source = "DemoApplicationDataSource"
+    Example: if you have a data_source "DemoApplicationDataSource" with the root package "models" and a sub package "Windmill",
+    the entire "Windmill" package can be exported using: absolute_document_reference = "DemoApplicationDataSource/models/Windmill"
 
-    The zip file is downloaded to the directory the command is called from.
+    Arguments:
+    absolute_document_reference: Path to document or package to export. Should be <dataSource>/<path>
+    export_location (Optional): Path to specify where to store the exported document(s). If not provided, will export to current folder.
     """
-    # path and data_source should not have a trailing or leading "/"
-    path = path.rstrip("/").lstrip("/")
-    data_source = data_source.rstrip("/").lstrip("/")
+    response = export(absolute_document_ref=absolute_document_reference)
 
-    export(absolute_document_ref=f"{data_source}/{path}")
-
+    if not export_location:
+        export_location = os.getcwd()
+    with ZipFile(io.BytesIO(response.content), "r") as zip_file:
+        zip_file.filename = f"{absolute_document_reference.split('/')[-1]}.zip"
+        if unpack:
+            unpack_and_save_zipfile(override=override, export_location=export_location, zip_file=zip_file)
+        else:
+            save_as_zip_file(override=override, export_location=export_location, filename=zip_file.filename, data=response.content)
 
 @pkg_cli.command("delete", help="Delete the package <package> in the given data source.")
 @click.argument("data_source", required=True)

--- a/dm_cli/dmss.py
+++ b/dm_cli/dmss.py
@@ -1,3 +1,29 @@
+import io
+import zipfile
+
+import requests
+
 from .dmss_api.api.default_api import DefaultApi
 
 dmss_api = DefaultApi()
+
+
+class Settings:
+    PUBLIC_DMSS_API: str = "http://localhost:5000"
+    DMSS_TOKEN: str | None = None
+
+
+settings = Settings()
+
+
+def export(absolute_document_ref: str):
+    """Call export endpoint from DMSS to download document(s) as zip.
+
+    The reason dmss_api cannot be used directly is that there were some issues with interpreting the JSON schema,
+    which caused the export function in the generated DMSS api to not work properly.
+    """
+    headers = {"Access-Key": settings.DMSS_TOKEN}
+
+    response = requests.get(f"{settings.PUBLIC_DMSS_API}/api/v1/export/{absolute_document_ref}", headers=headers)
+    zip_file = zipfile.ZipFile(io.BytesIO(response.content))
+    zip_file.extractall()

--- a/dm_cli/dmss.py
+++ b/dm_cli/dmss.py
@@ -1,7 +1,8 @@
-import io
-import zipfile
+from typing import Union
 
 import requests
+
+from dm_cli.utils import ApplicationException
 
 from .dmss_api.api.default_api import DefaultApi
 
@@ -10,7 +11,7 @@ dmss_api = DefaultApi()
 
 class Settings:
     PUBLIC_DMSS_API: str = "http://localhost:5000"
-    DMSS_TOKEN: str | None = None
+    DMSS_TOKEN: Union[str, None] = None
 
 
 settings = Settings()
@@ -25,5 +26,9 @@ def export(absolute_document_ref: str):
     headers = {"Access-Key": settings.DMSS_TOKEN}
 
     response = requests.get(f"{settings.PUBLIC_DMSS_API}/api/v1/export/{absolute_document_ref}", headers=headers)
-    zip_file = zipfile.ZipFile(io.BytesIO(response.content))
-    zip_file.extractall()
+    if response.status_code != 200:
+        raise ApplicationException(
+            message=f"Could not export document(s) from {absolute_document_ref} (status code {response.status_code})."
+        )
+
+    return response

--- a/dm_cli/dmss_api/api/default_api.py
+++ b/dm_cli/dmss_api/api/default_api.py
@@ -3299,7 +3299,7 @@ class DefaultApi(object):
 
             Keyword Args:
                 scope (dict): [optional]
-                time_to_live (int): [optional]
+                time_to_live (int): [optional] if omitted the server will use the default value of 2592000
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/dm_cli/dmss_api/api/personal_access_token_api.py
+++ b/dm_cli/dmss_api/api/personal_access_token_api.py
@@ -52,7 +52,7 @@ class PersonalAccessTokenApi(object):
 
             Keyword Args:
                 scope (dict): [optional]
-                time_to_live (int): [optional]
+                time_to_live (int): [optional] if omitted the server will use the default value of 2592000
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/dm_cli/dmss_api/model/error_response.py
+++ b/dm_cli/dmss_api/model/error_response.py
@@ -146,7 +146,7 @@ class ErrorResponse(ModelNormal):
             type (str): [optional] if omitted the server will use the default value of "ApplicationException"  # noqa: E501
             message (str): [optional] if omitted the server will use the default value of "The requested operation failed"  # noqa: E501
             debug (str): [optional] if omitted the server will use the default value of "An unknown and unhandled exception occurred in the API"  # noqa: E501
-            data ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501
+            data ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional] if omitted the server will use the default value of {}  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -232,7 +232,7 @@ class ErrorResponse(ModelNormal):
             type (str): [optional] if omitted the server will use the default value of "ApplicationException"  # noqa: E501
             message (str): [optional] if omitted the server will use the default value of "The requested operation failed"  # noqa: E501
             debug (str): [optional] if omitted the server will use the default value of "An unknown and unhandled exception occurred in the API"  # noqa: E501
-            data ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501
+            data ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional] if omitted the server will use the default value of {}  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/dm_cli/dmss_api/model/pat_data.py
+++ b/dm_cli/dmss_api/model/pat_data.py
@@ -156,7 +156,7 @@ class PATData(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             pat_hash (str): [optional]  # noqa: E501
-            uuid (str): [optional] if omitted the server will use the default value of "6bf0bd94-f0ad-4c31-a596-11b980ec667c"  # noqa: E501
+            uuid (str): [optional] if omitted the server will use the default value of "4873f1eb-9688-45a2-9458-bb305e729ed2"  # noqa: E501
             roles ([str]): [optional] if omitted the server will use the default value of []  # noqa: E501
         """
 
@@ -248,7 +248,7 @@ class PATData(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             pat_hash (str): [optional]  # noqa: E501
-            uuid (str): [optional] if omitted the server will use the default value of "6bf0bd94-f0ad-4c31-a596-11b980ec667c"  # noqa: E501
+            uuid (str): [optional] if omitted the server will use the default value of "4873f1eb-9688-45a2-9458-bb305e729ed2"  # noqa: E501
             roles ([str]): [optional] if omitted the server will use the default value of []  # noqa: E501
         """
 

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -121,18 +121,18 @@ def concat_dependencies(
 
 
 def unpack_and_save_zipfile(override: bool, export_location: str, zip_file: ZipFile):
-    """Unpack zipfile and save it to export_location.
+    """Unpack zipfile and save it to export_location. It is assumed that zip file only contains json files and folders.
     If override is True, any existing file/folder with the name of filename will be overwritten.
     """
     if ".zip" not in zip_file.filename:
         raise ApplicationException(message="file ending .zip must be included in filename!")
     zip_file_unpacked_path = f"{export_location}/{zip_file.filename.rstrip('.zip')}"
 
-    if not override and Path(zip_file_unpacked_path).exists():
-        if Path(zip_file_unpacked_path).exists():
-            new_path = f"{zip_file_unpacked_path.rstrip('.zip')}-{str(uuid4())}"
-            os.mkdir(new_path)
-            zip_file.extractall(path=new_path)
+    if not override and (Path(zip_file_unpacked_path).exists() or Path(f"{zip_file_unpacked_path}.json").exists()):
+        new_path = f"{zip_file_unpacked_path}-{str(uuid4())}"
+        os.mkdir(new_path)
+        zip_file.extractall(path=new_path)
+        # TODO fix saving of single file when override is False. If zip_file contains single file, a new folder will be created instead of a single file.
     else:
         zip_file.extractall(path=export_location)
 

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -153,11 +153,8 @@ def save_as_zip_file(overwrite: bool, export_location: str, filename: str, data:
     saved_zip_file_path = f"{export_location}/{filename}"
 
     if not overwrite and Path(saved_zip_file_path).exists():
-        new_zip_filename = f"{export_location}/{filename.rstrip('.zip')}-{str(uuid4())}.zip"
-        with open(new_zip_filename, "wb") as file:
-            file.write(data)
-            click.echo(f"Wrote zip file to '{new_zip_filename}'")
-    else:
-        with open(saved_zip_file_path, "wb") as file:
-            file.write(data)
-            click.echo(f"Wrote zip file to '{saved_zip_file_path}'")
+        saved_zip_file_path = f"{export_location}/{filename.rstrip('.zip')}-{str(uuid4())}.zip"
+
+    with open(saved_zip_file_path, "wb") as file:
+        file.write(data)
+        click.echo(f"Wrote zip file to '{saved_zip_file_path}'")

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -120,32 +120,32 @@ def concat_dependencies(
     return old_dependencies
 
 
-def unpack_and_save_zipfile(override: bool, export_location: str, zip_file: ZipFile):
+def unpack_and_save_zipfile(overwrite: bool, export_location: str, zip_file: ZipFile):
     """Unpack zipfile and save it to export_location. It is assumed that zip file only contains json files and folders.
-    If override is True, any existing file/folder with the name of filename will be overwritten.
+    If overwrite is True, any existing file/folder with the name of filename will be overwritten.
     """
     if ".zip" not in zip_file.filename:
         raise ApplicationException(message="file ending .zip must be included in filename!")
     zip_file_unpacked_path = f"{export_location}/{zip_file.filename.rstrip('.zip')}"
 
-    if not override and (Path(zip_file_unpacked_path).exists() or Path(f"{zip_file_unpacked_path}.json").exists()):
+    if not overwrite and (Path(zip_file_unpacked_path).exists() or Path(f"{zip_file_unpacked_path}.json").exists()):
         new_path = f"{zip_file_unpacked_path}-{str(uuid4())}"
         os.mkdir(new_path)
         zip_file.extractall(path=new_path)
-        # TODO fix saving of single file when override is False. If zip_file contains single file, a new folder will be created instead of a single file.
+        # TODO fix saving of single file when overwrite is False. If zip_file contains single file, a new folder will be created instead of a single file.
     else:
         zip_file.extractall(path=export_location)
 
 
-def save_as_zip_file(override: bool, export_location: str, filename: str, data: str):
+def save_as_zip_file(overwrite: bool, export_location: str, filename: str, data: str):
     """Save binary data into a zip file on the local disk.
-    If override is True, any existing zip file with the name of filename will be overwritten.
+    If overwrite is True, any existing zip file with the name of filename will be overwritten.
     """
     if ".zip" not in filename:
         raise ApplicationException(message="file ending .zip must be included in filename!")
     saved_zip_file_path = f"{export_location}/{filename}"
 
-    if not override and Path(saved_zip_file_path).exists():
+    if not overwrite and Path(saved_zip_file_path).exists():
         with open(f"{export_location}/{filename.rstrip('.zip')}-{str(uuid4())}.zip", "wb") as f:
             f.write(data)
     else:

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Literal, NewType
 from uuid import uuid4
 from zipfile import ZipFile
 
+import click
+
 
 class ApplicationException(Exception):
     status: int = 500
@@ -124,7 +126,7 @@ def unpack_and_save_zipfile(overwrite: bool, export_location: str, zip_file: Zip
     """Unpack zipfile and save it to export_location. It is assumed that zip file only contains json files and folders.
     If overwrite is True, any existing file/folder with the name of filename will be overwritten.
     """
-    if ".zip" not in zip_file.filename:
+    if not zip_file.filename.endswith(".zip"):
         raise ApplicationException(message="file ending .zip must be included in filename!")
     zip_file_unpacked_path = f"{export_location}/{zip_file.filename.rstrip('.zip')}"
 
@@ -141,13 +143,16 @@ def save_as_zip_file(overwrite: bool, export_location: str, filename: str, data:
     """Save binary data into a zip file on the local disk.
     If overwrite is True, any existing zip file with the name of filename will be overwritten.
     """
-    if ".zip" not in filename:
+    if not filename.endswith(".zip"):
         raise ApplicationException(message="file ending .zip must be included in filename!")
     saved_zip_file_path = f"{export_location}/{filename}"
 
     if not overwrite and Path(saved_zip_file_path).exists():
-        with open(f"{export_location}/{filename.rstrip('.zip')}-{str(uuid4())}.zip", "wb") as f:
-            f.write(data)
+        new_zip_filename = f"{export_location}/{filename.rstrip('.zip')}-{str(uuid4())}.zip"
+        with open(new_zip_filename, "wb") as file:
+            file.write(data)
+            click.echo(f"Wrote zip file to '{new_zip_filename}'")
     else:
-        with open(saved_zip_file_path, "wb") as f:
-            f.write(data)
+        with open(saved_zip_file_path, "wb") as file:
+            file.write(data)
+            click.echo(f"Wrote zip file to '{saved_zip_file_path}'")

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -136,7 +136,7 @@ def unpack_and_save_zipfile(export_location: str, zip_file: ZipFile):
         zip_file_unpacked_path += ".json"
 
     if Path(zip_file_unpacked_path).exists():
-        click.echo(emoji.emojize(f"\t:warning: File or folder '{zip_file_unpacked_path}' already exists. Exiting."))
+        click.echo(emoji.emojize(f"\t:error: File or folder '{zip_file_unpacked_path}' already exists. Exiting."))
         raise ApplicationException("Path already exists")
 
     zip_file.extractall(path=export_location)
@@ -152,7 +152,7 @@ def save_as_zip_file(export_location: str, filename: str, data: str):
     saved_zip_file_path = f"{export_location}/{filename}"
 
     if Path(saved_zip_file_path).exists():
-        click.echo(emoji.emojize(f"\t:warning: File or folder '{saved_zip_file_path}' already exists. Exiting."))
+        click.echo(emoji.emojize(f"\t:error: File or folder '{saved_zip_file_path}' already exists. Exiting."))
         raise ApplicationException("Path already exists")
 
     with open(saved_zip_file_path, "wb") as file:

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -126,15 +126,20 @@ def unpack_and_save_zipfile(overwrite: bool, export_location: str, zip_file: Zip
     """Unpack zipfile and save it to export_location. It is assumed that zip file only contains json files and folders.
     If overwrite is True, any existing file/folder with the name of filename will be overwritten.
     """
-    if not zip_file.filename.endswith(".zip"):
-        raise ApplicationException(message="file ending .zip must be included in filename!")
     zip_file_unpacked_path = f"{export_location}/{zip_file.filename.rstrip('.zip')}"
+    if len(zip_file.filelist) == 1:
+        # If single file in the zip file, the unpacked path has .json ending (we assume the zip file always contains json files)
+        zip_file_unpacked_path += ".json"
 
-    if not overwrite and (Path(zip_file_unpacked_path).exists() or Path(f"{zip_file_unpacked_path}.json").exists()):
-        new_path = f"{zip_file_unpacked_path}-{str(uuid4())}"
-        os.mkdir(new_path)
-        zip_file.extractall(path=new_path)
-        # TODO fix saving of single file when overwrite is False. If zip_file contains single file, a new folder will be created instead of a single file.
+    if not overwrite and (Path(zip_file_unpacked_path).exists()):
+        if len(zip_file.filelist) == 1:
+            file = zip_file.filelist[0]
+            file.filename = file.filename.replace(".json", f"-{str(uuid4())}.json")
+            zip_file.extract(file)
+        else:
+            new_path = f"{zip_file_unpacked_path}-{str(uuid4())}"
+            os.mkdir(new_path)
+            zip_file.extractall(path=new_path)
     else:
         zip_file.extractall(path=export_location)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.21",
+    version="0.1.22",
     author="",
     author_email="",
     license="MIT",


### PR DESCRIPTION
## What does this pull request change?
add new cli command to export documents from dmss to local disk.
The export function from the generated dmss api could not be used, since there were issues with the JSON schema. It seems like the open api generator is not working properly when content is of type "application/zip" (the returned data was None instead of binary representation of the zip)

## Why is this pull request needed?
download documents

## Issues related to this change
closes https://github.com/equinor/dm-cli/issues/39