### PR TITLE
fix: bug with object type in  replace_relative_references()

### DIFF
--- a/dm_cli/enums.py
+++ b/dm_cli/enums.py
@@ -1,6 +1,5 @@
 from enum import Enum
 
-PRIMITIVES = {"string", "number", "integer", "boolean"}
 
 
 class StorageDataTypes(Enum):

--- a/dm_cli/enums.py
+++ b/dm_cli/enums.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
 
-
 class StorageDataTypes(Enum):
     DEFAULT = "default"
     LARGE = "large"

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -12,7 +12,7 @@ import emoji
 from .dmss import ApplicationException, dmss_api
 from .dmss_api.exceptions import ApiException
 from .domain import Dependency
-from .enums import PRIMITIVES, SIMOS, BuiltinDataTypes
+from .enums import SIMOS, BuiltinDataTypes
 
 
 def find_reference_schema(reference: str) -> Literal["dmss", "alias", "dotted", "package", "data_source"]:
@@ -172,7 +172,7 @@ def replace_relative_references(
                     )
                 )
             return extends_list
-        if key == "attributeType" and (value in PRIMITIVES or value == BuiltinDataTypes.OBJECT.value):
+        if key == "attributeType" and value in [data_type.value for data_type in BuiltinDataTypes]:
             return value
         return resolve_reference(
             value,

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -12,7 +12,7 @@ import emoji
 from .dmss import ApplicationException, dmss_api
 from .dmss_api.exceptions import ApiException
 from .domain import Dependency
-from .enums import PRIMITIVES, SIMOS
+from .enums import PRIMITIVES, SIMOS, BuiltinDataTypes
 
 
 def find_reference_schema(reference: str) -> Literal["dmss", "alias", "dotted", "package", "data_source"]:
@@ -172,7 +172,7 @@ def replace_relative_references(
                     )
                 )
             return extends_list
-        if key == "attributeType" and value in PRIMITIVES:
+        if key == "attributeType" and (value in PRIMITIVES or value == BuiltinDataTypes.OBJECT.value):
             return value
         return resolve_reference(
             value,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setup(
     name="dm-cli",
-    version="0.1.26",
+    version="0.1.27",
     author="",
     author_email="",
     license="MIT",


### PR DESCRIPTION
## What does this pull request change?
fix bug with object type
## Why is this pull request needed?
when using "object" for attribute type, the value is translated to a path when running the dm-cli reset command.
![image](https://user-images.githubusercontent.com/69512295/211753777-4097bfb8-c603-446a-9985-8382e673c72b.png)

## Issues related to this change

