### PR TITLE
feature: import single entity and use remote meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Options:
 
 Commands:
   create-lookup  Create a named Ui-/StorageRecipe-lookup-table from all...
-  ds     Subcommand for working with data sources
-  init   Initialize the data sources and import all packages.
-  pkg    Subcommand for working with packages
-  reset  Reset all data sources (deletes and reuploads packages)
+  ds             Subcommand for working with data sources
+  entity         Subcommand for working with entities
+  init           Initialize the data sources and import all packages.
+  pkg            Subcommand for working with packages
+  reset          Reset all data sources (deletes and reuploads packages)
 ```
 
 For each of the `commands` listed above, you can run `dm <COMMAND> --help` to see subcommand-specific help messages, e.g. `dm ds import --help` or `dm pkg --help`
@@ -49,11 +50,11 @@ For these commands, the `path` argument must be the path to a directory with two
 $ tree app
 app
 ├── data
-│   └── DemoApplicationDataSource
-│       ├── instances
-│       │   └── demoApplication.json
-│       └── models
-│           └── DemoApplication.json
+  └── DemoApplicationDataSource
+    ├── instances
+│     └── demoApplication.json
+|     └── models
+|       └── DemoApplication.json
 └── data_sources
     └── DemoApplicationDataSource.json
 ```
@@ -195,6 +196,14 @@ Delete all packages
 # Delete all packages found in the directory given by <path>
 $ dm pkg delete-all <data_source> <path>
 $ dm pkg delete-all DemoApplicationDataSource app/data/DemoApplicationDataSource
+```
+
+### Entities
+
+Upload a single entity
+
+```sh
+$ dm entity import <local_path> <destination_path>
 ```
 
 ### Recipe Lookup

--- a/dm_cli/__init__.py
+++ b/dm_cli/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.28"
+VERSION = "1.0.0"

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/demoApplication.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/demoApplication.json
@@ -2,5 +2,6 @@
   "_id": "4483c9b0-d505-46c9-a157-94c79f4d7a6a",
   "type": "TEST-MODELS:DemoApplication",
   "label": "Demo App",
-  "dataSources": ["DemoApplicationDataSource"]
+  "dataSources": ["DemoApplicationDataSource"],
+  "name": "DemoApplication"
 }


### PR DESCRIPTION
## What does this pull request change?
- Grabs "meta" from remote target and merge with meta from the entity on "single entity upload"

## Why is this pull request needed?
- Sane default behavior

## Issues related to this change
closes #61 
