### PR TITLE
fix: dont try to resolve '_default_' blueprintPath

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
         language_version: python3.8
@@ -13,7 +13,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 23.1.0
     hooks:
       - id: black
         language_version: python3.8
@@ -24,7 +24,7 @@ repos:
           - --line-length=119
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
+    rev: 1.7.5
     hooks:
       - id: bandit
         args: [-l, --recursive, -x, tests, --skip, B311]
@@ -32,7 +32,7 @@ repos:
         exclude: ^dm_cli/dmss_api/
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -41,7 +41,7 @@ repos:
         args: [ "--profile=black"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: "5.0.0"
+    rev: "6.0.0"
     hooks:
       - id: flake8
         files: ^./dm_cli/.*\.py$

--- a/dm_cli/dmss.py
+++ b/dm_cli/dmss.py
@@ -53,7 +53,7 @@ def export(absolute_document_ref: str):
     """
     headers = {"Access-Key": settings.DMSS_TOKEN}
 
-    response = requests.get(f"{settings.PUBLIC_DMSS_API}/api/export/{absolute_document_ref}", headers=headers)
+    response = requests.get(f"{settings.PUBLIC_DMSS_API}/api/export/{absolute_document_ref}", headers=headers)  # nosec
     if response.status_code != 200:
         raise ApplicationException(
             message=f"Could not export document(s) from {absolute_document_ref} (status code {response.status_code})."

--- a/dm_cli/utils.py
+++ b/dm_cli/utils.py
@@ -50,7 +50,7 @@ def resolve_reference(reference: str, dependencies: Dict[str, Dependency], data_
     root_package = file_path.split("/", 1)[0]
     ref_schema = find_reference_schema(reference)
 
-    if ref_schema == "dmss":
+    if ref_schema == "dmss" or reference == "_default_":
         return reference
     if ref_schema == "alias":
         return resolve_dependency(reference, dependencies)


### PR DESCRIPTION
## What does this pull request change?
- Dont modify keyword "_default_" during import

## Why is this pull request needed?
- "_default_" was interpreted as as reference. When in fact it's a special keyword that should be kept

## Issues related to this change
closes #66 
