### PR TITLE
ci: don't call publish on push to main

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -7,9 +7,3 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/tests.yaml
-
-  publish-packages:
-      needs: tests
-      uses: ./.github/workflows/publish.yaml
-      secrets:
-        PYPI_DM_CLI_TOKEN: ${{ secrets.PYPI_DM_CLI_TOKEN }}


### PR DESCRIPTION
## What does this pull request change?
- Remove "publish" workflow call in ""push-to-main"

## Why is this pull request needed?
- Should only be one trigger for "publish"(on-tag)

## Issues related to this change
none

