### PR TITLE
feature: added shorthand command for plugin blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,24 @@ Both the above commands would install the package globally and `dm` will be avai
 
 ## Usage
 
-```sh
+```txt
 $ dm --help
-Usage: python -m dm [OPTIONS] COMMAND [ARGS]...
+Usage: dm [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  -t, --token TEXT  Token for authentication against DMSS.
-  -u, --url TEXT    URL to the Data Modelling Storage Service (DMSS).
-  -h, --help        Show this message and exit.
+--version         Show the version and exit.
+-t, --token TEXT  Token for authentication against DMSS.
+-u, --url TEXT    URL to the Data Modelling Storage Service (DMSS).
+-h, --help        Show this message and exit.
 
 Commands:
-  create-lookup  Create a named Ui-/StorageRecipe-lookup-table from all...
-  ds             Subcommand for working with data sources
-  entity         Subcommand for working with entities
-  init           Initialize the data sources and import all packages.
-  pkg            Subcommand for working with packages
-  reset          Reset all data sources (deletes and reuploads packages)
+create-lookup             Create a named Ui-/StorageRecipe-lookup-table...
+ds                        Subcommand for working with data sources
+entity                    Subcommand for working with entities
+import-plugin-blueprints  Import blueprints from a plugin into the...
+init                      Initialize the data sources and import all...
+pkg                       Subcommand for working with packages
+reset                     Reset all data sources (deletes and reuploads...
 ```
 
 For each of the `commands` listed above, you can run `dm <COMMAND> --help` to see subcommand-specific help messages, e.g. `dm ds import --help` or `dm pkg --help`
@@ -143,6 +145,16 @@ $ dm ds reset DemoApplicationDataSource
 # Optionally specify a path to the directory containing data sources and data
 $ dm ds reset DemoApplicationDataSource app/
 ```
+
+### Plugin blueprints
+Import blueprints from a plugin into the default plugin blueprint path (`system/Plugins/<plugin-name>)
+
+```shell
+dm import-plugin-blueprints ./node_modules/@development-framework/dm-core-plugins
+```
+> Note that this is the same as;
+> `dm entity import ./node_modules/@development-framework/dm-core-plugins/blueprints/ system/Plugins/dm-core-plugins`
+
 
 ### Packages
 Import a package

--- a/dm_cli/__init__.py
+++ b/dm_cli/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.2"
+VERSION = "1.0.3"

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -431,6 +431,14 @@ def reset(context, path: str):
 def create_lookup(context, name: str, path: str):
     dmss_api.create_lookup(recipe_package=path, application=name)
 
+@cli.command()
+@click.argument("path", required=True)
+@click.pass_context
+def import_plugin_blueprints(context, path: str):
+    """Import blueprints from a plugin into the standard location 'system/Plugins/<plugin-name>'
+
+    PATH: Path to file or folder on local filesystem to import. Trailing '/' will result in the content being imported instead of the folder itself"""
+    context.invoke(import_entity, source=f"{path}/blueprints/", destination=f"system/Plugins/{Path(path).name}", force=True)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## What does this pull request change?
- Adds a shorthand command for importing blueprints from plugins

## Why is this pull request needed?
- Simplify importing blueprints from plugins

## Issues related to this change
closes #64 

