### PR TITLE
fix: bug with generate package content dict

### DIFF
--- a/dm_cli/domain.py
+++ b/dm_cli/domain.py
@@ -92,25 +92,27 @@ class Package:
             if isinstance(child, Package):
                 result.append(
                     {
-                        "_id": str(child.uid),
-                        "name": child.name,
-                        "type": SIMOS.PACKAGE.value,
-                        "contained": True,
+                        "ref": str(child.uid),
+                        "targetName": child.name,
+                        "targetType": SIMOS.PACKAGE.value,
+                        "type": "dmss://system/SIMOS/Link",
                     }
                 )
             else:  # Assume the child is a dict
                 if "name" in child:
                     result.append(
                         {
-                            "_id": child["_id"],
-                            "name": child["name"],
-                            "type": child["type"],
-                            "contained": True,
+                            "ref": child["_id"],
+                            "targetName": child["name"],
+                            "targetType": child["type"],
+                            "type": "dmss://system/SIMOS/Link",
                         }
                     )
 
                 else:
-                    result.append({"_id": child["_id"], "type": child["type"], "contained": True})
+                    result.append(
+                        {"ref": child["_id"], "targetType": child["type"], "type": "dmss://system/SIMOS/Link"}
+                    )
         return result
 
 

--- a/dm_cli/utils/utils.py
+++ b/dm_cli/utils/utils.py
@@ -1,9 +1,11 @@
 import io
 import json
+import pprint
 from pathlib import Path
 from typing import Dict, List
 from uuid import uuid4
 
+import typer
 from rich import print
 from rich.console import Console
 
@@ -120,11 +122,11 @@ def ensure_package_structure(path: Path):
     try:
         dmss_api.document_get_by_path(f"dmss://{path}")
     except NotFoundException as e:
-        # error = json.loads(e.body)
-        # if str(f"'{path}'") not in error["message"]:
-        #     print(f"Target package '{path}' is likely corrupt!")
-        #     print(f"\n\t{pprint.pprint(error)}")
-        #     raise typer.Exit(code=1)
+        error = json.loads(e.body)
+        if str(f"{path}") not in error["message"]:
+            print(f"Target package '{path}' is likely corrupt!")
+            pprint.pformat(error)
+            raise typer.Exit(code=1)
 
         if len(path.parts) > 2:  # We're at root package level. Do not check for datasource.
             ensure_package_structure(path.parent)


### PR DESCRIPTION
## What does this pull request change?
fix bug with converting Package class object to dict. 

Update the way the content list of a package is generated as JSON, to be compatible with the new reference scheme



## Issues related to this change
closes #81 

https://github.com/equinor/data-modelling-storage-service/pull/397 must be merged before tests pass

