### PR TITLE
tests: run integration tests with build pipy-package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # Order matter. If two rules match the same file, only the last one is used
 
 # Repo owners
-*       @soofstad @netr0m @eoaksnes @KristianKjerstad
+*       @soofstad @netr0m @eoaksnes @KristianKjerstad @ingeridhellen
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,15 +43,18 @@ jobs:
           npm pack @development-framework/dm-core-plugins
           tar -xzf development-framework-dm-core-plugins-*.tgz
 
-      - name: Setup python
+      - name: Build and install dm-cli package
         run: |
+          cd ../..
           python -m venv .venv
           source .venv/bin/activate
-          pip install -e ../..
+          pip install wheel twine
+          python setup.py sdist bdist_wheel
+          pip install ./dist/dm-cli-*.tar.gz
 
       - name: Tests
         run: |
-          pip install -e ../..
+          source ../../.venv/bin/activate
           dm reset ../test_data/test_app_dir_struct
           dm import-plugin-blueprints package
           dm create-lookup test DemoApplicationDataSource/instances

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include requirements.txt

--- a/tests/integration/docker-compose.yaml
+++ b/tests/integration/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:latest
+    image: datamodelingtool.azurecr.io/dmss:v1.2.1 # TODO: Test with "latest" when fixes has been merged
     restart: unless-stopped
     environment:
       AUTH_ENABLED: 0


### PR DESCRIPTION
## What does this pull request change?
- Install dm-cli from the same ".tar.gz" bundle used when installing from pipy when running integration tests

## Why is this pull request needed?
- Test that the "to-be-published" package actually works


## Issues related to this change
closes #80 

