### PR TITLE
feat: create lookup table from several paths

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
           source ../../.venv/bin/activate
           dm reset ../test_data/test_app_dir_struct
           dm import-plugin-blueprints package
-          dm create-lookup test DemoApplicationDataSource/models/recipe_links
+          dm create-lookup test DemoApplicationDataSource/models/recipe_links DemoApplicationDataSource/models/more_recipe_links
           dm export DemoApplicationDataSource/models/CarPackage
           dm export DemoApplicationDataSource/instances --unpack
           dm ds import ../test_data/test_app_dir_struct/data_sources/DemoApplicationDataSource.json

--- a/dm_cli/__init__.py
+++ b/dm_cli/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.9"
+VERSION = "1.0.10"

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -2,7 +2,7 @@
 import io
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 from zipfile import ZipFile
 import emoji
 
@@ -57,14 +57,17 @@ def import_plugin_blueprints(path: str):
     import_entity(source=f"{path}/blueprints/", destination=f"system/Plugins/{Path(path).name}")
 
 @app.command("create-lookup")
-def create_lookup(name: str, path: str):
+def create_lookup(name: str, paths: List[Path]):
     """
     Create a named Ui-/StorageRecipe-lookup-table from all RecipeLinks in a package existing in DMSS (requires admin privileges)
 
     NAME: name of the lookup(application context) to create
-    PATH: remote location for recursively looking for RecipeLinks
+    PATHS: one or more remote location for recursively looking for RecipeLinks
     """
-    dmss_exception_wrapper(dmss_api.create_lookup, recipe_package=path, application=name)
+
+    paths_as_strings = [str(path) for path in paths]
+    print(f"Creating lookup table from paths: {paths_as_strings}")
+    dmss_exception_wrapper(dmss_api.create_lookup, recipe_package=paths_as_strings, application=name)
 
 @app.command("export")
 def export_entity(target: str, export_location: str = "", unpack: bool = False):

--- a/dm_cli/dmss_api/api/default_api.py
+++ b/dm_cli/dmss_api/api/default_api.py
@@ -583,7 +583,7 @@ class DefaultApi(object):
         ):
             """Create Lookup  # noqa: E501
 
-            Create a recipe lookup table from a package containing RecipeLinks. Associate it with an application. This can be used for setting Ui- and StorageRecipes for specific applications.  - **application**: name of application  # noqa: E501
+            Create a recipe lookup table from a package containing RecipeLinks. Associate it with an application. This can be used for setting Ui- and StorageRecipes for specific applications.  - **application**: name of application - **recipe_package**: List with one or more paths to package(s) that contain recipe links. (Example: 'system/SIMOS/recipe_links')  # noqa: E501
             This method makes a synchronous HTTP request by default. To make an
             asynchronous HTTP request, please pass async_req=True
 
@@ -592,7 +592,7 @@ class DefaultApi(object):
 
             Args:
                 application (str):
-                recipe_package (str):
+                recipe_package ([str]):
 
             Keyword Args:
                 _return_http_data_only (bool): response data without head status
@@ -682,7 +682,7 @@ class DefaultApi(object):
                     'application':
                         (str,),
                     'recipe_package':
-                        (str,),
+                        ([str],),
                 },
                 'attribute_map': {
                     'application': 'application',
@@ -693,6 +693,7 @@ class DefaultApi(object):
                     'recipe_package': 'query',
                 },
                 'collection_format_map': {
+                    'recipe_package': 'multi',
                 }
             },
             headers_map={
@@ -1502,7 +1503,8 @@ class DefaultApi(object):
                 reference (str):
 
             Keyword Args:
-                depth (int): [optional] if omitted the server will use the default value of 999
+                depth (int): [optional] if omitted the server will use the default value of 0
+                resolve_links (bool): [optional] if omitted the server will use the default value of False
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -1567,6 +1569,7 @@ class DefaultApi(object):
                 'all': [
                     'reference',
                     'depth',
+                    'resolve_links',
                 ],
                 'required': [
                     'reference',
@@ -1588,14 +1591,18 @@ class DefaultApi(object):
                         (str,),
                     'depth':
                         (int,),
+                    'resolve_links':
+                        (bool,),
                 },
                 'attribute_map': {
                     'reference': 'reference',
                     'depth': 'depth',
+                    'resolve_links': 'resolve_links',
                 },
                 'location_map': {
                     'reference': 'path',
                     'depth': 'query',
+                    'resolve_links': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/dm_cli/dmss_api/api/document_api.py
+++ b/dm_cli/dmss_api/api/document_api.py
@@ -470,7 +470,8 @@ class DocumentApi(object):
                 reference (str):
 
             Keyword Args:
-                depth (int): [optional] if omitted the server will use the default value of 999
+                depth (int): [optional] if omitted the server will use the default value of 0
+                resolve_links (bool): [optional] if omitted the server will use the default value of False
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -535,6 +536,7 @@ class DocumentApi(object):
                 'all': [
                     'reference',
                     'depth',
+                    'resolve_links',
                 ],
                 'required': [
                     'reference',
@@ -556,14 +558,18 @@ class DocumentApi(object):
                         (str,),
                     'depth':
                         (int,),
+                    'resolve_links':
+                        (bool,),
                 },
                 'attribute_map': {
                     'reference': 'reference',
                     'depth': 'depth',
+                    'resolve_links': 'resolve_links',
                 },
                 'location_map': {
                     'reference': 'path',
                     'depth': 'query',
+                    'resolve_links': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/dm_cli/dmss_api/api/lookup_table_api.py
+++ b/dm_cli/dmss_api/api/lookup_table_api.py
@@ -45,7 +45,7 @@ class LookupTableApi(object):
         ):
             """Create Lookup  # noqa: E501
 
-            Create a recipe lookup table from a package containing RecipeLinks. Associate it with an application. This can be used for setting Ui- and StorageRecipes for specific applications.  - **application**: name of application  # noqa: E501
+            Create a recipe lookup table from a package containing RecipeLinks. Associate it with an application. This can be used for setting Ui- and StorageRecipes for specific applications.  - **application**: name of application - **recipe_package**: List with one or more paths to package(s) that contain recipe links. (Example: 'system/SIMOS/recipe_links')  # noqa: E501
             This method makes a synchronous HTTP request by default. To make an
             asynchronous HTTP request, please pass async_req=True
 
@@ -54,7 +54,7 @@ class LookupTableApi(object):
 
             Args:
                 application (str):
-                recipe_package (str):
+                recipe_package ([str]):
 
             Keyword Args:
                 _return_http_data_only (bool): response data without head status
@@ -144,7 +144,7 @@ class LookupTableApi(object):
                     'application':
                         (str,),
                     'recipe_package':
-                        (str,),
+                        ([str],),
                 },
                 'attribute_map': {
                     'application': 'application',
@@ -155,6 +155,7 @@ class LookupTableApi(object):
                     'recipe_package': 'query',
                 },
                 'collection_format_map': {
+                    'recipe_package': 'multi',
                 }
             },
             headers_map={

--- a/dm_cli/dmss_api/model/pat_data.py
+++ b/dm_cli/dmss_api/model/pat_data.py
@@ -156,7 +156,7 @@ class PATData(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             pat_hash (str): [optional]  # noqa: E501
-            uuid (str): [optional] if omitted the server will use the default value of "e298aba4-84af-4270-bf81-6f11f48680b0"  # noqa: E501
+            uuid (str): [optional] if omitted the server will use the default value of "f95ff174-036b-4895-93f9-2a6fd782d005"  # noqa: E501
             roles ([str]): [optional] if omitted the server will use the default value of []  # noqa: E501
         """
 
@@ -248,7 +248,7 @@ class PATData(ModelNormal):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             pat_hash (str): [optional]  # noqa: E501
-            uuid (str): [optional] if omitted the server will use the default value of "e298aba4-84af-4270-bf81-6f11f48680b0"  # noqa: E501
+            uuid (str): [optional] if omitted the server will use the default value of "f95ff174-036b-4895-93f9-2a6fd782d005"  # noqa: E501
             roles ([str]): [optional] if omitted the server will use the default value of []  # noqa: E501
         """
 

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/more_recipe_links/wheel.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/more_recipe_links/wheel.json
@@ -1,0 +1,16 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "CarPackage/Wheel",
+  "uiRecipes": [
+    {
+      "name": "Yaml",
+      "type": "CORE:UiRecipe",
+      "plugin": "@development-framework/dm-core-plugins/yaml"
+    },
+    {
+      "type": "CORE:UiRecipe",
+      "name": "Form",
+      "plugin": "@development-framework/dm-core-plugins/form"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this pull request change?
add functionality to create lookup table from several paths into a single app. The generated dmss api is also updated
## Why is this pull request needed?

## Issues related to this change
closes #90 assumed that https://github.com/equinor/data-modelling-storage-service/pull/428 has been merged

