### PR TITLE
fix: remove uiRecipes from blueprints

### DIFF
--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Car.json
@@ -28,6 +28,5 @@
       "attributeType": "CarPackage/Wheel",
       "dimensions": "*"
     }
-  ],
-  "uiRecipes": []
+  ]
 }

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/EnginePackage/Engine.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/EnginePackage/Engine.json
@@ -9,6 +9,5 @@
       "type": "CORE:BlueprintAttribute",
       "attributeType": "string"
     }
-  ],
-  "uiRecipes": []
+  ]
 }

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Wheel.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/CarPackage/Wheel.json
@@ -14,7 +14,5 @@
       "type": "CORE:BlueprintAttribute",
       "label": "string"
     }
-  ],
-  "storageRecipes": [],
-  "uiRecipes": []
+  ]
 }

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/DemoApplication.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/DemoApplication.json
@@ -17,13 +17,5 @@
       "dimensions": "*",
       "optional": false
     }
-  ],
-  "uiRecipes": [
-    {
-      "name": "Default",
-      "type": "CORE:UiRecipe",
-      "plugin": "demoApp",
-      "category": "Application"
-    }
   ]
 }

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExtendsRelative.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExtendsRelative.json
@@ -17,13 +17,5 @@
       "dimensions": "*",
       "optional": false
     }
-  ],
-  "uiRecipes": [
-    {
-      "name": "Default",
-      "type": "CORE:UiRecipe",
-      "plugin": "demoApp",
-      "category": "Application"
-    }
   ]
 }

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExternalFile.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/ExternalFile.json
@@ -18,7 +18,5 @@
       "attributeType": "string",
       "optional": true
     }
-  ],
-  "uiRecipes": [
   ]
 }


### PR DESCRIPTION
## What does this pull request change?
remove uiRecipes from blueprints, that should not be included. This attribute is not specified in CORE:Blueprint 

## Issues related to this change

