### PR TITLE
Fix/replace references in meta for subpackages

### DIFF
--- a/dm_cli/package_tree_from_zip.py
+++ b/dm_cli/package_tree_from_zip.py
@@ -11,7 +11,10 @@ from .import_package import (
     add_object_to_package,
     add_package_to_package,
 )
-from .utils.reference import replace_relative_references
+from .utils.reference import (
+    replace_relative_references,
+    replace_relative_references_in_package_meta,
+)
 from .utils.utils import concat_dependencies
 
 
@@ -102,9 +105,7 @@ def package_tree_from_zip(
             update=True,
         )
 
-        # Make sure to replace relative references in _meta_
-        root_package.meta = replace_relative_references(
-            "_meta_", root_package.meta, dependencies, data_source_id, file_path=root_package.path()
-        )
+        # Make sure to replace relative references in _meta_ for all packages
+        replace_relative_references_in_package_meta(root_package, dependencies, data_source_id)
 
     return root_package

--- a/dm_cli/utils/reference.py
+++ b/dm_cli/utils/reference.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Union
 
 from ..domain import Dependency
 from ..enums import SIMOS, BuiltinDataTypes
-from .utils import resolve_dependency
+from .utils import Package, resolve_dependency
 
 
 def resolve_reference(reference: str, dependencies: Dict[str, Dependency], data_source: str, file_path: str) -> str:
@@ -20,6 +20,25 @@ def resolve_reference(reference: str, dependencies: Dict[str, Dependency], data_
     if reference[0] == "/":
         return f"dmss://{data_source}{reference}"
     return f"dmss://{data_source}/{root_package}/{reference}"
+
+
+def replace_relative_references_in_package_meta(
+    package: Package, dependencies: Dict[str, Dependency], data_source_id: str
+) -> Package:
+    """
+    Replace relative references in meta attribute of the package and subpackages inside the package's content list.
+    Recursively dig down into the package structure and replace the references inside the meta attribute of the package.
+    """
+
+    package.meta = replace_relative_references(
+        "_meta_", package.meta, dependencies, data_source_id, file_path=package.path()
+    )
+
+    for document in package.content:
+        if type(document) == Package:
+            replace_relative_references_in_package_meta(document, dependencies, data_source_id)
+
+    return package
 
 
 def replace_relative_references(


### PR DESCRIPTION
## What does this pull request change?

When running reset command, all aliases in all sub package's meta must be replaced. Before, only references in the root package's meta info was replaced.

replacing a reference means substituting the alias (e.g. CORE) with the full path (dmss://system/SIMOS)

## Issues related to this change
closes #109 
