### PR TITLE
feat: be able to upload DMSS blueprints

### DIFF
--- a/dm_cli/command_group/data_source.py
+++ b/dm_cli/command_group/data_source.py
@@ -121,7 +121,10 @@ def import_data_source_file(data_sources_dir: str, data_dir: str, data_source_de
                 import_folder_entity,
                 source_path=data_source_data_dir / root_package.name,
                 destination=data_source_name,
-                raw=True
+                # Use the document raw endpoint,
+                # so that uploaded packages will not be resolved,
+                # this is to support uploading core blueprints.
+                raw_package_import=True,
             )
 
 

--- a/dm_cli/command_group/data_source.py
+++ b/dm_cli/command_group/data_source.py
@@ -121,6 +121,7 @@ def import_data_source_file(data_sources_dir: str, data_dir: str, data_source_de
                 import_folder_entity,
                 source_path=data_source_data_dir / root_package.name,
                 destination=data_source_name,
+                raw=True
             )
 
 

--- a/dm_cli/enums.py
+++ b/dm_cli/enums.py
@@ -16,6 +16,7 @@ class BuiltinDataTypes(Enum):
     BOOL = "boolean"
     OBJECT = "object"  # Any complex type (i.e. any blueprint type)
     BINARY = "binary"
+    ANY = "any"
 
     def to_py_type(self):
         if self is BuiltinDataTypes.BOOL:

--- a/dm_cli/import_entity.py
+++ b/dm_cli/import_entity.py
@@ -68,7 +68,7 @@ def import_single_entity(source_path: Path, destination: str):
         raise Exception(f"Failed to load the file '{source_path.name}' as a JSON document")
 
 
-def import_folder_entity(source_path: Path, destination: str) -> None:
+def import_folder_entity(source_path: Path, destination: str, raw=False) -> None:
     print(f"Importing PACKAGE '{source_path.name}' --> '{destination}/'")
     destination_path = Path(destination)
     data_source = destination_path.parts[0]
@@ -101,4 +101,4 @@ def import_folder_entity(source_path: Path, destination: str) -> None:
     memory_file.seek(0)
 
     package = package_tree_from_zip(data_source, memory_file, is_root=is_root, extra_dependencies=dependencies)
-    import_package_tree(package, destination)
+    import_package_tree(package, destination, raw)

--- a/dm_cli/import_entity.py
+++ b/dm_cli/import_entity.py
@@ -68,7 +68,7 @@ def import_single_entity(source_path: Path, destination: str):
         raise Exception(f"Failed to load the file '{source_path.name}' as a JSON document")
 
 
-def import_folder_entity(source_path: Path, destination: str, raw=False) -> None:
+def import_folder_entity(source_path: Path, destination: str, raw_package_import=False) -> None:
     print(f"Importing PACKAGE '{source_path.name}' --> '{destination}/'")
     destination_path = Path(destination)
     data_source = destination_path.parts[0]
@@ -101,4 +101,4 @@ def import_folder_entity(source_path: Path, destination: str, raw=False) -> None
     memory_file.seek(0)
 
     package = package_tree_from_zip(data_source, memory_file, is_root=is_root, extra_dependencies=dependencies)
-    import_package_tree(package, destination, raw)
+    import_package_tree(package, destination, raw_package_import)

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -71,36 +71,19 @@ def add_package_to_package(path: Path, package: Package) -> None:
     return add_package_to_package(Path(new_path), sub_folder)
 
 
-def import_package_tree(package: Package, destination: str, raw: bool) -> None:
+def import_package_tree(package: Package, destination: str, raw_package_import: bool) -> None:
     destination_parts = destination.split("/")
     data_source = destination_parts[0]
 
-    if len(destination_parts) == 1:  # We're importing a root package
-        if raw:
-            dmss_api.document_add_simple(
-                data_source,
-                body=package.to_dict()
-            )
-        else:
-            dmss_api.document_add(
-                destination,
-                json.dumps(package.to_dict()),
-                update_uncontained=False,
-                files=[],
-            )
-    else:  # We're importing a sub folder
-        if raw:
-            dmss_api.document_add_simple(
-                data_source,
-                body=package.to_dict()
-            )
-        else:
-            dmss_api.document_add(
-                destination,
-                json.dumps(package.to_dict()),
-                update_uncontained=False,
-                files=[],
-            )
+    if raw_package_import:
+        dmss_api.document_add_simple(data_source, body=package.to_dict())
+    else:
+        dmss_api.document_add(
+            destination,
+            json.dumps(package.to_dict()),
+            update_uncontained=False,
+            files=[],
+        )
 
     documents_to_upload: List[dict] = []
     package.traverse_documents(lambda document, **kwargs: documents_to_upload.append(document))

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -71,24 +71,36 @@ def add_package_to_package(path: Path, package: Package) -> None:
     return add_package_to_package(Path(new_path), sub_folder)
 
 
-def import_package_tree(package: Package, destination: str) -> None:
+def import_package_tree(package: Package, destination: str, raw: bool) -> None:
     destination_parts = destination.split("/")
     data_source = destination_parts[0]
 
     if len(destination_parts) == 1:  # We're importing a root package
-        dmss_api.document_add(
-            destination,
-            json.dumps(package.to_dict()),
-            update_uncontained=False,
-            files=[],
-        )
+        if raw:
+            dmss_api.document_add_simple(
+                data_source,
+                body=package.to_dict()
+            )
+        else:
+            dmss_api.document_add(
+                destination,
+                json.dumps(package.to_dict()),
+                update_uncontained=False,
+                files=[],
+            )
     else:  # We're importing a sub folder
-        dmss_api.document_add(
-            destination,
-            json.dumps(package.to_dict()),
-            update_uncontained=False,
-            files=[],
-        )
+        if raw:
+            dmss_api.document_add_simple(
+                data_source,
+                body=package.to_dict()
+            )
+        else:
+            dmss_api.document_add(
+                destination,
+                json.dumps(package.to_dict()),
+                update_uncontained=False,
+                files=[],
+            )
 
     documents_to_upload: List[dict] = []
     package.traverse_documents(lambda document, **kwargs: documents_to_upload.append(document))

--- a/dm_cli/utils/reference.py
+++ b/dm_cli/utils/reference.py
@@ -81,7 +81,11 @@ def replace_relative_references(
         "address",
     )  # These keys may contain a reference
 
-    if value == BuiltinDataTypes.OBJECT.value or value == BuiltinDataTypes.BINARY.value:
+    if (
+        value == BuiltinDataTypes.OBJECT.value
+        or value == BuiltinDataTypes.BINARY.value
+        or value == BuiltinDataTypes.ANY.value
+    ):
         return value
 
     if key in KEYS_TO_CHECK:
@@ -111,7 +115,11 @@ def replace_relative_references(
         if not value.get("type"):
             raise KeyError(f"Object with key '{key}' is missing the required 'type' attribute. File: '{file_path}'")
 
-        if value.get("type") == BuiltinDataTypes.OBJECT.value or value.get("type") == BuiltinDataTypes.BINARY.value:
+        if (
+            value.get("type") == BuiltinDataTypes.OBJECT.value
+            or value.get("type") == BuiltinDataTypes.BINARY.value
+            or value.get("type") == BuiltinDataTypes.ANY.value
+        ):
             return value
 
         resolved_type = resolve_reference(


### PR DESCRIPTION
## What does this pull request change?

To be able to upload the core blueprints in DMSS needed to make two changes:

1. When dm reset app is called, it will not use the add document endpoint for adding packages, but instead just upload the using the document raw endpoint.
2. Don't try to replace_relative_references of the attribute type any (e.g. to replace the relative address to files on disk). The any type is used in the DMSS core blueprints.

## Why is this pull request needed?

## Issues related to this change

