### PR TITLE
feat: support global data source storage

### DIFF
--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -96,7 +96,7 @@ def export_entity(target: Annotated[str, typer.Argument(help="Address to the ent
 @app.command("reset")
 def reset(path: Annotated[str, typer.Argument(help="The path on local file system to the data source you want to reset.")],
           validate_entities: Annotated[bool, typer.Option(help="if True, all entities uploaded to DMSS will be validated.")] = True,
-          resolve_local_ids: Annotated[bool, typer.Option(help="if True, will resolve all local ids found in all entities")] = True):
+          resolve_local_ids: Annotated[bool, typer.Option(help="if True, will resolve all local ids found in all entities")] = False):
     """
     Reset all data sources (deletes and re-uploads all packages to DMSS).
     """

--- a/dm_cli/command_group/entities.py
+++ b/dm_cli/command_group/entities.py
@@ -38,10 +38,10 @@ def import_entity(
                 if file.is_file():
                     dmss_exception_wrapper(import_single_entity, file, destination)
                     continue
-                dmss_exception_wrapper(import_folder_entity, file, destination)
+                dmss_exception_wrapper(import_folder_entity, file, destination, None)
             return True
         print(f"Importing PACKAGE '{source}' --> '{destination}'")
-        dmss_exception_wrapper(import_folder_entity, source_path, destination)
+        dmss_exception_wrapper(import_folder_entity, source_path, destination, None)
         return True
     else:
         dmss_exception_wrapper(import_single_entity, source_path, destination)

--- a/dm_cli/domain.py
+++ b/dm_cli/domain.py
@@ -7,6 +7,17 @@ from uuid import UUID, uuid4
 from .enums import SIMOS, ReferenceTypes
 
 
+@dataclass(frozen=False)
+class Entity:
+    content: dict
+    filename: str
+    name: str = ""
+    directory: str = ""
+
+    def __getitem__(self, item):
+        return self.__getattribute__(item)
+
+
 @dataclass(frozen=True)
 class File:
     """Class for a file"""
@@ -34,7 +45,7 @@ class Package:
         self.description = description
         self.uid = uid if uid else uuid4()
         self.is_root = is_root
-        self.content: List[Union[Package, dict, File]] = []
+        self.content: List[Union[Package, File, Entity]] = []
         self.meta: Union[dict, None] = meta if meta else {}
         self.parent = parent if parent else None
 
@@ -120,24 +131,14 @@ class Package:
                         "referenceType": ReferenceTypes.STORAGE.value,
                     }
                 )
-            else:  # Assume the child is a dict
-                if "name" in child:
-                    result.append(
-                        {
-                            "address": f"${child['_id']}",
-                            "type": SIMOS.REFERENCE.value,
-                            "referenceType": ReferenceTypes.STORAGE.value,
-                        }
-                    )
-
-                else:
-                    result.append(
-                        {
-                            "address": f"${child['_id']}",
-                            "type": SIMOS.REFERENCE.value,
-                            "referenceType": ReferenceTypes.STORAGE.value,
-                        }
-                    )
+            elif isinstance(child, Entity):
+                result.append(
+                    {
+                        "address": f"${str(child.content['_id'])}",
+                        "type": SIMOS.REFERENCE.value,
+                        "referenceType": ReferenceTypes.STORAGE.value,
+                    }
+                )
         return result
 
 

--- a/dm_cli/import_entity.py
+++ b/dm_cli/import_entity.py
@@ -69,7 +69,11 @@ def import_single_entity(source_path: Path, destination: str):
 
 
 def import_folder_entity(
-    source_path: Path, destination: str, raw_package_import: bool = False, resolve_local_ids: bool = False
+    source_path: Path,
+    destination: str,
+    raw_package_import: bool = False,
+    global_ids: dict = None,
+    resolve_local_ids: bool = False,
 ) -> None:
     print(f"Importing PACKAGE '{source_path.name}' --> '{destination}/'")
     destination_path = Path(destination)
@@ -103,4 +107,4 @@ def import_folder_entity(
     memory_file.seek(0)
 
     package = package_tree_from_zip(data_source, memory_file, is_root=is_root, extra_dependencies=dependencies)
-    import_package_tree(package, destination, raw_package_import, resolve_local_ids)
+    import_package_tree(package, destination, global_ids, raw_package_import, resolve_local_ids)

--- a/dm_cli/package_tree_from_zip.py
+++ b/dm_cli/package_tree_from_zip.py
@@ -68,7 +68,7 @@ def package_tree_from_zip(
                 continue
             if Path(filename).suffix != ".json":
                 file_like = io.BytesIO(zip_file.read(f"{folder_name}/{filename}"))
-                print(f"\tAdding file {filename} ({file_like.getbuffer().nbytes} bytes)")
+                # print(f"\tAdding file {filename} ({file_like.getbuffer().nbytes} bytes)")
                 file_like.name = Path(filename).name  # stem
                 file_like.destination = Path(f"/{data_source_id}/{folder_name}/{filename}").parent
                 add_object_to_package(Path(filename), root_package, file_like)
@@ -87,7 +87,7 @@ def package_tree_from_zip(
 
         def replace(document, file_path):
             if not isinstance(document, File):
-                document = {
+                document.content = {
                     key: replace_relative_references(
                         key,
                         value,
@@ -96,7 +96,7 @@ def package_tree_from_zip(
                         file_path=file_path,
                         zip_file=zip_file,
                     )
-                    for key, value in document.items()
+                    for key, value in document.content.items()
                 }
             return document
 

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
         "dm_cli/dmss_api/model",
     ],
     install_requires=[requirements],
-    python_requires=">=3.11",
+    python_requires=">=3.8",
     classifiers=[
-        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
     ],
     scripts=[

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/global/globalEntity.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/global/globalEntity.json
@@ -1,0 +1,7 @@
+{
+  "_id": "4483c9b0-d505-46c9-a157-94c79f4d7a6b",
+  "name": "SimulationResult",
+  "type": "/models/storage_uncontained/Result",
+  "description": "Example simulation",
+  "value": 10000000000
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/simulation.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/instances/simulation.json
@@ -1,0 +1,11 @@
+{
+  "_id": "simulation1",
+  "name": "simulation1",
+  "type": "/models/storage_uncontained/Simulation",
+  "description": "Example simulation",
+  "result": {
+    "type": "CORE:Reference",
+    "address": "/global/globalEntity.json",
+    "referenceType": "storage"
+  }
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/recipe_links/simulation.recipe.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/recipe_links/simulation.recipe.json
@@ -1,0 +1,18 @@
+{
+  "type": "CORE:RecipeLink",
+  "_blueprintPath_": "/models/storage_uncontained/Simulation",
+  "storageRecipes": [
+    {
+      "name": "DEFAULT",
+      "type": "dmss://system/SIMOS/StorageRecipe",
+      "description": "",
+      "attributes": [
+        {
+          "name": "result",
+          "type": "dmss://system/SIMOS/StorageAttribute",
+          "contained": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/storage_uncontained/Result.blueprint.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/storage_uncontained/Result.blueprint.json
@@ -1,0 +1,14 @@
+{
+  "name": "Result",
+  "type": "CORE:Blueprint",
+  "extends": [
+    "CORE:NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "value",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "number"
+    }
+  ]
+}

--- a/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/storage_uncontained/Simulation.blueprint.json
+++ b/tests/test_data/test_app_dir_struct/data/DemoApplicationDataSource/models/storage_uncontained/Simulation.blueprint.json
@@ -1,0 +1,15 @@
+{
+  "name": "Simulation",
+  "type": "CORE:Blueprint",
+  "extends": [
+    "CORE:NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "result",
+      "type": "CORE:BlueprintAttribute",
+      "attributeType": "./Result",
+      "optional": true
+    }
+  ]
+}

--- a/tests/test_data/test_app_dir_struct/data_sources/DemoApplicationDataSource.json
+++ b/tests/test_data/test_app_dir_struct/data_sources/DemoApplicationDataSource.json
@@ -14,5 +14,8 @@
         "blob"
       ]
     }
-  }
+  },
+  "global_folders": [
+    "global"
+  ]
 }

--- a/tests/unit/test_import_package.py
+++ b/tests/unit/test_import_package.py
@@ -254,29 +254,35 @@ class ImportPackageTest(unittest.TestCase):
         folder_SubFolder = folder_A.search("SubFolder")
         myTurbine2 = folder_SubFolder.search("myTurbine2")
 
-        assert mooringBlueprint["type"] == "dmss://system/SIMOS/Blueprint"
+        assert mooringBlueprint.content["type"] == "dmss://system/SIMOS/Blueprint"
 
-        assert myTurbine2["type"] == "dmss://test_data_source/MyRootPackage/WindTurbine"
-        assert isinstance(UUID(myTurbine2["Mooring"]["_id"]), UUID)
-        assert myTurbine2["Mooring"]["type"] == "dmss://test_data_source/MyRootPackage/Moorings/Mooring"
-        assert myTurbine2["Mooring"]["_id"] == myTurbineMooring["_id"]
+        assert myTurbine2.content["type"] == "dmss://test_data_source/MyRootPackage/WindTurbine"
+        assert isinstance(UUID(myTurbine2.content["Mooring"]["_id"]), UUID)
+        assert myTurbine2.content["Mooring"]["type"] == "dmss://test_data_source/MyRootPackage/Moorings/Mooring"
+        assert myTurbine2.content["Mooring"]["_id"] == myTurbineMooring.content["_id"]
 
         windTurbine = root_package.search("WindTurbine")
-        assert isinstance(UUID(windTurbine["_id"]), UUID)
+        assert isinstance(UUID(windTurbine.content["_id"]), UUID)
         assert (
-            windTurbine["attributes"][0]["attributeType"] == "dmss://test_data_source/MyRootPackage/Moorings/Mooring"
+            windTurbine.content["attributes"][0]["attributeType"]
+            == "dmss://test_data_source/MyRootPackage/Moorings/Mooring"
         )
-        assert (windTurbine["attributes"][1]["attributeType"]) == "http://marine-models.sintef.com/Signals/Default"
-        assert windTurbine["extends"] == [
+        assert (
+            windTurbine.content["attributes"][1]["attributeType"]
+        ) == "http://marine-models.sintef.com/Signals/Default"
+        assert windTurbine.content["extends"] == [
             "dmss://system/SIMOS/DefaultUiRecipes",
             "dmss://system/SIMOS/NamedEntity",
         ]
-        assert windTurbine["_meta_"]["version"] == "0.0.1" and len(windTurbine["_meta_"]["dependencies"]) == 1
+        assert (
+            windTurbine.content["_meta_"]["version"] == "0.0.1"
+            and len(windTurbine.content["_meta_"]["dependencies"]) == 1
+        )
 
         specialMooring = folder_Moorings.search("SpecialMooring")
-        assert len(specialMooring["extends"]) == 3
-        assert specialMooring["extends"][2] == "dmss://test_data_source/MyRootPackage/Moorings/Mooring"
-        assert specialMooring["attributes"][1]["type"] == "dmss://test_data_source/AnotherPackage/MyType"
+        assert len(specialMooring.content["extends"]) == 3
+        assert specialMooring.content["extends"][2] == "dmss://test_data_source/MyRootPackage/Moorings/Mooring"
+        assert specialMooring.content["attributes"][1]["type"] == "dmss://test_data_source/AnotherPackage/MyType"
 
         test_pdf = root_package.search("test_pdf.pdf")
         assert isinstance(test_pdf, File)


### PR DESCRIPTION
## What does this pull request change?

Add support for "global folders" by configuring it in the data source files like this:

```
{
  "name": "SomeDataSource",
  "repositories": {
    ....
  },
  "global_folders": [
    "global"
  ]
}
```

This will make the files inside the "global" folder global. 

It is possible to reference the global files on disk like this.

```
{
    "type": "CORE:Reference",
    "address": "/global/<filename>.json",
    "referenceType": "storage"
 }
```

The address will upon uploading be replaced with the global id that the document got during import. 

## Why is this pull request needed?

## Issues related to this change

