### PR TITLE
feat: retry requests on network errors

### DIFF
--- a/dm_cli/dmss.py
+++ b/dm_cli/dmss.py
@@ -5,6 +5,12 @@ import requests
 import typer
 from rich.console import Console
 from rich.text import Text
+from tenacity import (
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from dm_cli.dmss_api import ApiException
 from dm_cli.dmss_api.api.default_api import DefaultApi
@@ -46,6 +52,12 @@ class ApplicationException(Exception):
         }
 
 
+@retry(
+    wait=wait_random_exponential(multiplier=1, max=60),
+    stop=stop_after_attempt(5),
+    reraise=True,
+    retry=retry_if_not_exception_type(ApplicationException),
+)
 def export(absolute_document_ref: str):
     """Call export endpoint from DMSS to download document(s) as zip.
 

--- a/generate-dmss-api.sh
+++ b/generate-dmss-api.sh
@@ -8,7 +8,7 @@ echo "Creating DMSS Python package version $PACKAGE_VERSION"
 docker run --rm \
 --network="host" \
 -v ${PWD}/dm_cli/dmss_api:/local/dm_cli/dmss_api/ \
-openapitools/openapi-generator-cli:v6.0.0 generate \
+openapitools/openapi-generator-cli:v7.1.0 generate \
 -i http://localhost:5000/openapi.json  \
 -g python \
 -o /local/dm_cli \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ frozendict>=2.3.8
 typing_extensions>=4.7.1
 typer[all]>=0.9.0
 python-dateutil>=2.8.2
+tenacity>=8.2.3


### PR DESCRIPTION
## What does this pull request change?
- Adds "Tenacity's" retry decorator for some of the functions communicating with DMSS
Tenacity: https://tenacity.readthedocs.io/en/latest/

## Why is this pull request needed?
- CI fails to reset DMSS once in a while.

## Issues related to this change
closes #146 
