### PR TITLE
fix: resolve storage references on disk

### DIFF
--- a/dm_cli/package_tree_from_zip.py
+++ b/dm_cli/package_tree_from_zip.py
@@ -23,6 +23,7 @@ def package_tree_from_zip(
     zip_package: io.BytesIO,
     is_root: bool = True,
     extra_dependencies: Union[Dict[str, Dependency], None] = None,
+    source_path: Path = None,
 ) -> Package:
     """
     Converts a Zip-folder into a DMSS Package structure.
@@ -32,6 +33,8 @@ def package_tree_from_zip(
 
     @param data_source_id: A string with the name/id of an existing data source to import package to
     @param zip_package: A zip-folder represented as an in-memory io.BytesIO object
+    @param source_path: path to the root folder
+
     @return: A Package object with sub folders(Package) and documents(dict)
     """
 
@@ -94,6 +97,7 @@ def package_tree_from_zip(
                         data_source_id,
                         file_path=file_path,
                         zip_file=zip_file,
+                        source_path=source_path,
                     )
                     for key, value in document.items()
                 }


### PR DESCRIPTION
## What does this pull request change?
- Remove zip file for global folder
- Resolve storage references and locate them directly from disk when uploading global files

## Why is this pull request needed?
Global folder is only zipped if defined in the data source. It should be possible to upload files just by knowing their location on disk.

## Issues related to this change

