### PR TITLE
feature: validation on single entity upload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
           python-version: "3.11"
 
       - name: Start DMSS
-        run: docker-compose pull && docker-compose up -d && sleep 60 && docker-compose run --rm dmss reset-app
+        run: docker-compose pull && docker-compose up -d
 
       - name: Download test blueprints
         run: |
@@ -68,14 +68,14 @@ jobs:
         run: |
           source ../../.venv/bin/activate
           dm reset ../test_data/test_app_dir_struct
-          dm import-plugin-blueprints package
+          dm import-plugin-blueprints --no-validate package
           dm create-lookup test DemoApplicationDataSource/models/recipe_links DemoApplicationDataSource/models/more_recipe_links
           dm export DemoApplicationDataSource/models/CarPackage
           dm export DemoApplicationDataSource/instances --unpack
           dm ds import ../test_data/test_app_dir_struct/data_sources/DemoApplicationDataSource.json
           dm ds import-all ../test_data/test_app_dir_struct/data_sources
-          dm entities import ../test_data/more_documents/bmw.json DemoApplicationDataSource/instances
-          dm entities import ../test_data/more_documents/engines DemoApplicationDataSource/instances
+          dm entities import --no-validate ../test_data/more_documents/bmw.json DemoApplicationDataSource/instances
+          dm entities import --no-validate ../test_data/more_documents/engines DemoApplicationDataSource/instances
           dm entities delete DemoApplicationDataSource/instances
           dm ds reset DemoApplicationDataSource ../test_data/test_app_dir_struct
           dm ds init ../test_data/test_app_dir_struct

--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -48,12 +48,15 @@ def main(
     dmss_api.api_client.configuration.host = dmss_url
 
 @app.command("import-plugin-blueprints")
-def import_plugin_blueprints(path: Annotated[str, typer.Argument(help="Path to file or folder on local filesystem to import. Trailing '/' will result in the content being imported instead of the folder itself.")]):
+def import_plugin_blueprints(
+        path: Annotated[str, typer.Argument(help="Path to file or folder on local filesystem to import. Trailing '/' will result in the content being imported instead of the folder itself.")],
+        validate: Annotated[bool, typer.Option(help="if True, all entities uploaded will be validated.")] = True
+):
     """
     Import blueprints from a plugin into the standard location 'system/Plugins/<plugin-name>'.
     """
     state.force = True
-    import_entity(source=f"{path}/blueprints/", destination=f"system/Plugins/{Path(path).name}")
+    import_entity(source=f"{path}/blueprints/", destination=f"system/Plugins/{Path(path).name}", validate=validate)
 
 @app.command("create-lookup")
 def create_lookup(name: Annotated[str, typer.Argument(help="Name of the lookup (application context) to create.")],

--- a/dm_cli/command_group/data_source.py
+++ b/dm_cli/command_group/data_source.py
@@ -117,6 +117,7 @@ def import_data_source_file(
 
             # Import all root packages
             for root_package in root_packages:
+                print(f"Importing PACKAGE '{data_source_data_dir / root_package.name}' --> '{data_source_name}'")
                 dmss_exception_wrapper(
                     import_folder_entity,
                     source_path=data_source_data_dir / root_package.name,

--- a/dm_cli/import_entity.py
+++ b/dm_cli/import_entity.py
@@ -59,7 +59,6 @@ def import_document(source_path: Path, destination: str, data_source_id: str, pa
     dmss_api.document_add(
         f"{destination}",
         document_json_str,
-        update_uncontained=True,
         files=[],
     )
 
@@ -98,7 +97,6 @@ def import_folder_entity(
     raw_package_import: bool = False,
     resolve_local_ids: bool = False,
 ) -> dict:
-    print(f"Importing PACKAGE '{source_path.name}' --> '{destination}/'")
     destination_path = Path(destination)
     data_source = destination_path.parts[0]
 

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -51,7 +51,7 @@ def add_file_to_package(path: Path, package: Package, document: dict) -> None:
     if len(path.parts) == 1:  # End of path means the actual document
         if path.name.endswith("package.json"):
             # if document is a package.json file, add meta info to package instead of adding it to content list.
-            package.meta = document["_meta_"]
+            package.meta = document.get("_meta_", {})
             return
         # Create a UUID if the document does not have one
         package.content.append({**document, "_id": document.get("_id", str(uuid4()))})
@@ -90,7 +90,6 @@ def import_package_tree(package: Package, destination: str, raw_package_import: 
         dmss_api.document_add(
             destination,
             json.dumps(package.to_dict()),
-            update_uncontained=False,
             files=[],
         )
 

--- a/dm_cli/utils/utils.py
+++ b/dm_cli/utils/utils.py
@@ -64,7 +64,6 @@ def add_package_to_path(name: str, path: Path):
     dmss_api.document_add(
         str(path.parent),
         json.dumps(package.to_dict()),
-        update_uncontained=False,
         files=[],
     )
 


### PR DESCRIPTION
## What does this pull request change?
- fix: _meta_ might not exist in every package.json
- feat: option to validate plugin blueprints
- feat: option to validate on 'entity' command + separate validate command

## Why is this pull request needed?
Validation was only available for "reset app".

