### PR TITLE
feat: check context before replacing type references

### DIFF
--- a/dm_cli/bin/dm
+++ b/dm_cli/bin/dm
@@ -122,7 +122,7 @@ def reset(path: Annotated[str, typer.Argument(help="The path on local file syste
             )
             continue
 
-        reset_data_source(data_source=data_source_name, path=path, resolve_local_ids=resolve_local_ids)
+        dmss_exception_wrapper(reset_data_source, data_source=data_source_name, path=path, resolve_local_ids=resolve_local_ids)
     data_source_contents = get_root_packages_in_data_sources(path)
     if (validate_entities):
         dmss_exception_wrapper(validate_entities_in_data_sources, data_source_contents)

--- a/dm_cli/command_group/entities.py
+++ b/dm_cli/command_group/entities.py
@@ -88,7 +88,7 @@ def validate_entity(
     @retry(
         wait=wait_random_exponential(multiplier=1, max=60),
         stop=stop_after_attempt(5),
-        retry=retry_if_not_exception_type(ApplicationException),
+        retry=retry_if_not_exception_type((ApplicationException, RuntimeError)),
     )
     def validation_error_wrapper():
         try:
@@ -97,7 +97,7 @@ def validate_entity(
             exception_body = json.loads(e.body)
             if exception_body["type"] == "ValidationException":
                 console.print(exception_body, style="red1")
-                return
+                raise typer.Exit(code=1)
             raise e
 
     dmss_exception_wrapper(validation_error_wrapper)

--- a/dm_cli/enums.py
+++ b/dm_cli/enums.py
@@ -37,6 +37,9 @@ class SIMOS(Enum):
     REFERENCE = "dmss://system/SIMOS/Reference"
     FILE = "dmss://system/SIMOS/File"
     DEPENDENCY = "dmss://system/SIMOS/Dependency"
+    ATTRIBUTE = "dmss://system/SIMOS/BlueprintAttribute"
+    BLUEPRINT = "dmss://system/SIMOS/Blueprint"
+    RECIPE_LINK = "dmss://system/SIMOS/RecipeLink"
 
 
 class ReferenceTypes(Enum):

--- a/dm_cli/import_entity.py
+++ b/dm_cli/import_entity.py
@@ -44,9 +44,7 @@ def import_document(source_path: Path, destination: str, document: dict):
     )
 
     # Replace references
-    prepared_document = {}
-    for key, val in document.items():
-        prepared_document[key] = replace_relative_references(key, val, dependencies, destination)
+    prepared_document = replace_relative_references(document, dependencies, destination)
 
     document_json_str = json.dumps(prepared_document)
     dmss_api.document_add(

--- a/tests/integration/docker-compose.yaml
+++ b/tests/integration/docker-compose.yaml
@@ -2,13 +2,13 @@ version: "3.4"
 
 services:
   dmss:
-    image: datamodelingtool.azurecr.io/dmss:v1.15.1
+    image: datamodelingtool.azurecr.io/dmss:v1.23.1
     restart: unless-stopped
     environment:
       AUTH_ENABLED: 0
       ENVIRONMENT: local
-      MONGO_INITDB_ROOT_USERNAME: maf
-      MONGO_INITDB_ROOT_PASSWORD: maf
+      MONGO_USERNAME: maf
+      MONGO_PASSWORD: maf
       SECRET_KEY: sg9aeUM5i1JO4gNN8fQadokJa3_gXQMLBjSGGYcfscs= # Don't reuse this in production...
     ports:
       - "5000:5000"
@@ -16,7 +16,7 @@ services:
       - db
 
   db:
-    image: mongo:3.4
+    image: mongo:3.6
     command: mongod --quiet
     environment:
       MONGO_INITDB_ROOT_USERNAME: maf

--- a/tests/unit/test_import_package.py
+++ b/tests/unit/test_import_package.py
@@ -109,6 +109,7 @@ test_documents = {
                 "type": "CORE:BlueprintAttribute",
                 "description": "How small? Not that small really",
                 "attributeType": "integer",
+                "default": 1,
             },
             {
                 "name": "ComplexTypeFromAnotherPacakge",
@@ -121,6 +122,11 @@ test_documents = {
                 "type": "CORE:BlueprintAttribute",
                 "description": "Type from parent folder",
                 "attributeType": "../WindTurbine",
+                "default": {
+                    "name": "myTurbine",
+                    "type": "../WindTurbine",
+                    "description": "This is a wind turbine demoing uncontained relationships",
+                },
             },
         ],
     },
@@ -277,6 +283,10 @@ class ImportPackageTest(unittest.TestCase):
         assert len(specialMooring["extends"]) == 3
         assert specialMooring["extends"][2] == "dmss://test_data_source/XRoot/MyPackage/Moorings/Mooring"
         assert specialMooring["attributes"][1]["type"] == "dmss://test_data_source/AnotherPackage/MyType"
+        assert specialMooring["attributes"][0]["default"] == 1
+        assert (
+            specialMooring["attributes"][2]["default"]["type"] == "dmss://test_data_source/XRoot/MyPackage/WindTurbine"
+        )
 
         test_pdf = root_package.search("test_pdf.pdf")
         assert isinstance(test_pdf, File)


### PR DESCRIPTION
## What does this pull request change?
- Refactor `replace_relative_references()` to check type of dict before replacing
  - This also made it simpler, faster, and more robust
- Added a few more cases to the tests
- Upgrade DMSS version used in tests
- dm-cli exit with 1 on validation error, halting  any scripts with "set -e"


## Why is this pull request needed?
see #145 

## Issues related to this change
closes #145 

