### PR TITLE
fix: validate single entities before upload

### DIFF
--- a/dm_cli/command_group/data_source.py
+++ b/dm_cli/command_group/data_source.py
@@ -6,13 +6,14 @@ import typer
 from rich import print
 from tenacity import (
     retry,
-    retry_if_not_exception_type,
+    retry_if_exception_type,
     stop_after_attempt,
     wait_random_exponential,
 )
 from typing_extensions import Annotated
 
 from dm_cli.dmss import ApplicationException, dmss_api, dmss_exception_wrapper
+from dm_cli.dmss_api.exceptions import ServiceException
 from dm_cli.import_entity import import_folder_entity, remove_by_path_ignore_404
 from dm_cli.utils.file_structure import get_app_dir_structure, get_json_files_in_dir
 from dm_cli.utils.utils import (
@@ -35,7 +36,7 @@ def import_data_source(
         wait=wait_random_exponential(multiplier=1, max=60),
         stop=stop_after_attempt(5),
         reraise=True,
-        retry=retry_if_not_exception_type(ApplicationException),
+        retry=retry_if_exception_type(ServiceException),
     )
     def retry_wrapper():
         data_source_path = Path(path)

--- a/dm_cli/command_group/entities.py
+++ b/dm_cli/command_group/entities.py
@@ -50,7 +50,7 @@ def import_entity(
                 print(f"Importing all content from '{source}*' --> '{destination}'")
                 for file in source_path.iterdir():
                     if file.is_file():
-                        import_single_entity(file, destination)
+                        import_single_entity(file, destination, validate)
                         continue
                     import_folder_entity(file, destination, fast)
                     if validate:
@@ -64,10 +64,7 @@ def import_entity(
                 dmss_api.validate_existing_entity(f"{destination}/{source_path.name}")
             return True
         else:
-            import_single_entity(source_path, destination)
-            if validate:
-                print(f"Validating entities in: {destination}/{source_path.name}")
-                dmss_api.validate_existing_entity(f"{destination}/{source_path.name}")
+            import_single_entity(source_path, destination, validate)
             return True
 
     return dmss_exception_wrapper(inner_import)

--- a/dm_cli/import_package.py
+++ b/dm_cli/import_package.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from rich.console import Console
 from tenacity import (
     retry,
+    retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
     wait_random_exponential,
@@ -15,6 +16,7 @@ from tenacity import (
 from tqdm import tqdm
 
 from .dmss import ApplicationException, dmss_api
+from .dmss_api.exceptions import ServiceException
 from .domain import Dependency, File, Package
 from .utils.reference import replace_relative_references
 from .utils.resolve_local_ids import resolve_local_ids_in_document
@@ -96,7 +98,7 @@ def import_package_tree(package: Package, destination: str, raw_package_import: 
     wait=wait_random_exponential(multiplier=1, max=60),
     stop=stop_after_attempt(5),
     reraise=True,
-    retry=retry_if_not_exception_type(ApplicationException),
+    retry=retry_if_exception_type(ServiceException),
 )
 def import_package_content(package: Package, data_source: str, destination: str, resolve_local_ids: bool) -> None:
     files: List[File] = []


### PR DESCRIPTION
Fix a bug where the filename was used to determine remote target for validation. This does not work, as the file name can not be determined, and will definitely not have a .json ending.

## Issues related to this change
closes #172 

